### PR TITLE
Исправление: выравнивание кнопки поиска в меню относительно поля поис…

### DIFF
--- a/frontend/styles/menu.css
+++ b/frontend/styles/menu.css
@@ -211,6 +211,38 @@
     align-items: center;
     gap: 10px;
 }
+/* Google CSE searchbox alignment fix: ensure input and button share the same baseline */
+.menu-search-row .gsc-control-cse,
+.menu-search-row .gsc-control-searchbox-only,
+.menu-search-row .gsc-search-box,
+.menu-search-row .gsc-search-box-tools,
+.menu-search-row .gsc-search-button,
+.menu-search-row .gsc-input-box,
+.menu-search-row .gsc-input,
+.menu-search-row .gsc-search-button-v2 {
+    display: flex;
+    align-items: center;
+}
+
+/* Normalize intrinsic heights so the button doesn't sit higher than the input */
+.menu-search-row .gsc-input-box,
+.menu-search-row .gsc-input {
+    height: 34px;
+}
+
+.menu-search-row .gsc-search-button.gsc-search-button-v2 {
+    height: 34px;
+    min-height: 34px;
+    line-height: 34px;
+}
+
+/* Remove extra vertical margins that can push elements off-baseline */
+.menu-search-row .gsc-search-button.gsc-search-button-v2,
+.menu-search-row input,
+.menu-search-row button {
+    margin-top: 0;
+    margin-bottom: 0;
+}
 
 .icon {
     display: inline-block;                                              /* Устанавливает элемент как встроенный блок */


### PR DESCRIPTION

- Привёл элементы .gcse к flex и align-items:center
- Нормализовал высоту (34px) для кнопки и поля
- Сбросил вертикальные отступы у кнопки/инпута внутри меню

Проверено на страницах игр и новостей, где подключается menu.css.