### PR TITLE
Replace banned social networks with VKontakte for Russian users

### DIFF
--- a/frontend/tools/ecology/calculator.js
+++ b/frontend/tools/ecology/calculator.js
@@ -471,11 +471,8 @@ class EcoFootprintCalculator {
         let shareUrl = '';
         
         switch (platform) {
-            case 'facebook':
-                shareUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}&quote=${encodeURIComponent(text)}`;
-                break;
-            case 'twitter':
-                shareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`;
+            case 'vk':
+                shareUrl = `https://vk.com/share.php?url=${encodeURIComponent(url)}&title=${encodeURIComponent('Калькулятор экологического следа продуктов')}&description=${encodeURIComponent(text)}`;
                 break;
             case 'telegram':
                 shareUrl = `https://t.me/share/url?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`;

--- a/frontend/tools/ecology/product-footprint-calculator.html
+++ b/frontend/tools/ecology/product-footprint-calculator.html
@@ -16,11 +16,10 @@
     <meta property="og:url" content="https://serpmonn.ru/eco-calculators/product-footprint/">
     <meta property="og:type" content="website">
     
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Калькулятор экологического следа продуктов">
-    <meta name="twitter:description" content="Рассчитайте экологический след ваших продуктов питания">
-    <meta name="twitter:image" content="https://serpmonn.ru/frontend/images/eco-calculator-banner.png">
+    <!-- VKontakte -->
+    <meta property="vk:title" content="Калькулятор экологического следа продуктов">
+    <meta property="vk:description" content="Рассчитайте экологический след ваших продуктов питания">
+    <meta property="vk:image" content="https://serpmonn.ru/frontend/images/eco-calculator-banner.png">
     
     <link rel="icon" href="/frontend/images/serpmonn.ico" type="image/x-icon">
     <link rel="canonical" href="https://serpmonn.ru/frontend/tools/ecology/product-footprint-calculator.html">
@@ -337,12 +336,12 @@
             background: #365899;
         }
 
-        .share-btn.twitter {
-            background: #1DA1F2;
+        .share-btn.vk {
+            background: #4680C2;
         }
 
-        .share-btn.twitter:hover {
-            background: #0d8bd9;
+        .share-btn.vk:hover {
+            background: #3a6ba5;
         }
 
         .share-btn.telegram {
@@ -432,11 +431,8 @@
             </div>
 
             <div class="share-buttons">
-                <button class="share-btn" onclick="shareResults('facebook')">
-                    📘 Поделиться в Facebook
-                </button>
-                <button class="share-btn twitter" onclick="shareResults('twitter')">
-                    🐦 Поделиться в Twitter
+                <button class="share-btn vk" onclick="shareResults('vk')">
+                    📘 Поделиться ВКонтакте
                 </button>
                 <button class="share-btn telegram" onclick="shareResults('telegram')">
                     📱 Поделиться в Telegram


### PR DESCRIPTION
- Removed Facebook and Twitter share buttons (banned in Russia)
- Added VKontakte share button with proper styling
- Updated meta tags: replaced Twitter meta with VKontakte meta
- Updated JavaScript: replaced Facebook/Twitter cases with VK case
- VK share URL: https://vk.com/share.php with proper parameters
- Kept Telegram as it's allowed in Russia
- Now compliant with Russian internet regulations