### PR TITLE
Исправлена высота кнопки поиска в мобильной версии главной страницы

### DIFF
--- a/frontend/styles/search.css
+++ b/frontend/styles/search.css
@@ -1,4 +1,4 @@
-.container {
+﻿.container {
 	text-align: center;                                                     /* Центрирование содержимого внутри контейнера */
 	background-color: rgba(255, 255, 255, 0.4);                             /* Полупрозрачный фон для читаемости */
 	border-radius: 10px;                                                    /* Радиус границы (округление углов) */
@@ -89,6 +89,20 @@ input, textarea, select, button {                                          /* С
 }
 
 @media (max-width: 600px) {
+        /* Стили для кнопки поиска на главной странице в мобильной версии */
+        .main-search-container .gsc-search-button.gsc-search-button-v2,
+        .main-search-container button.gsc-search-button {
+                min-height: 41px;
+                height: 41px !important;
+                padding: 0px 12px;
+                border-radius: 0 8px 8px 0;
+        }
+
+        /* Стили для поля поиска на главной странице в мобильной версии */
+        .main-search-container .gsc-input {
+                height: 41px !important;
+                min-height: 41px;
+        }
         .search-title { font-size: 22px; }
         .search-subtitle { font-size: 14px; }
         .cta-buttons { gap: 10px; }


### PR DESCRIPTION
- Добавлены мобильные стили для кнопки поиска на главной странице
- Увеличена высота кнопки с 34px до 41px на экранах менее 600px
- Добавлены стили для поля ввода поиска для соответствия высоте кнопки
- Теперь кнопка поиска корректно отображается в мобильной версии