### PR TITLE
Исправлена высота поля поиска в мобильной версии

### DIFF
--- a/frontend/styles/search.css
+++ b/frontend/styles/search.css
@@ -98,8 +98,6 @@ input, textarea, select, button {                                          /* С
                 border-radius: 0 8px 8px 0;
         }
 
-        /* Стили для поля поиска на главной странице в мобильной версии */
-        .main-search-container .gsc-input {
                 height: 41px !important;
                 min-height: 41px;
         }


### PR DESCRIPTION
- Удалены стили для поля ввода поиска, которые увеличивали его высоту
- Оставлены только стили для кнопки поиска (41px высота)
- Поле поиска теперь имеет стандартную высоту, кнопка - увеличенную
- Исправлено несоответствие размеров между полем и кнопкой поиска