### PR TITLE
feat(admin): создание почтового ящика @serpmonn.ru при добавлении сотрудника

### DIFF
--- a/frontend/admin/admin_scripts.js
+++ b/frontend/admin/admin_scripts.js
@@ -2,7 +2,6 @@
 // Токен хранится в httpOnly cookie admin_token — все запросы идут с credentials: 'include'
 
 const API = '/api/admin';
-const MAIL_API = '/mail-api';
 const PER_PAGE = 15;
 
 let allEmployees = [];
@@ -53,6 +52,32 @@ function roleLabel(r) {
 function formatDate(d) {
     if (!d) return '—';
     try { return new Date(d).toLocaleDateString('ru-RU'); } catch { return d; }
+}
+
+// --- TRANSLITERATE для автозаполнения логина почты ---
+function transliterate(str) {
+    const map = {
+        'а':'a','б':'b','в':'v','г':'g','д':'d','е':'e','ё':'e','ж':'zh','з':'z',
+        'и':'i','й':'j','к':'k','л':'l','м':'m','н':'n','о':'o','п':'p','р':'r',
+        'с':'s','т':'t','у':'u','ф':'f','х':'kh','ц':'ts','ч':'ch','ш':'sh','щ':'sch',
+        'ъ':'','ы':'y','ь':'','э':'e','ю':'yu','я':'ya',
+        'А':'A','Б':'B','В':'V','Г':'G','Д':'D','Е':'E','Ё':'E','Ж':'Zh','З':'Z',
+        'И':'I','Й':'J','К':'K','Л':'L','М':'M','Н':'N','О':'O','П':'P','Р':'R',
+        'С':'S','Т':'T','У':'U','Ф':'F','Х':'Kh','Ц':'Ts','Ч':'Ch','Ш':'Sh','Щ':'Sch',
+        'Ъ':'','Ы':'Y','Ь':'','Э':'E','Ю':'Yu','Я':'Ya'
+    };
+    return str.split('').map(c => map[c] !== undefined ? map[c] : c).join('');
+}
+
+function autoFillMailLocal() {
+    const mailLocalInput = document.getElementById('fmailLocal');
+    if (!mailLocalInput || document.getElementById('createMailbox')?.checked === false) return;
+    // Не перезаписываем если пользователь уже вручную что-то набрал
+    if (mailLocalInput.dataset.manualEdit === 'true') return;
+    const first = transliterate(document.getElementById('fname').value.trim()).toLowerCase().replace(/[^a-z0-9]/g, '');
+    const last  = transliterate(document.getElementById('lname').value.trim()).toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (first && last) mailLocalInput.value = `${first}.${last}`;
+    else if (first) mailLocalInput.value = first;
 }
 
 // --- FILTERS & RENDER ---
@@ -144,17 +169,11 @@ function openCreate() {
     document.getElementById('fpassword').required = true;
     document.querySelector('#passwordGroup small').style.display = 'none';
 
-    // email: разблокируем, сбрасываем
-    document.getElementById('femail').value = '';
-    document.getElementById('femail').readOnly = false;
-    document.getElementById('femailHint').style.display = 'none';
-
-    // блок mailbox показываем только при создании
-    document.getElementById('mailboxBlock').style.display = 'block';
-    document.getElementById('fCreateMailbox').checked = false;
+    // Показываем блок почты, сбрасываем состояние
+    document.getElementById('mailboxSection').style.display = 'block';
+    document.getElementById('createMailbox').checked = false;
     document.getElementById('mailboxFields').style.display = 'none';
-    document.getElementById('fMailboxPassword').value = '';
-    document.getElementById('fMailboxPassword').required = false;
+    document.getElementById('fmailLocal').dataset.manualEdit = 'false';
 
     document.getElementById('modalOverlay').classList.add('open');
     document.getElementById('fname').focus();
@@ -168,13 +187,7 @@ window.openEdit = function(id) {
     document.getElementById('employeeId').value = id;
     document.getElementById('fname').value = e.first_name || '';
     document.getElementById('lname').value = e.last_name || '';
-
-    // email при редактировании — показываем только локальную часть, блокируем
-    const emailLocal = (e.email || '').replace(/@serpmonn\.ru$/, '');
-    document.getElementById('femail').value = emailLocal;
-    document.getElementById('femail').readOnly = true;
-    document.getElementById('femailHint').style.display = 'block';
-
+    document.getElementById('femail').value = e.email || '';
     document.getElementById('frole').value = e.role || '';
     document.getElementById('fposition').value = e.position || '';
     document.getElementById('fstatus').value = e.status || 'active';
@@ -183,8 +196,10 @@ window.openEdit = function(id) {
     document.getElementById('fpassword').required = false;
     document.querySelector('#passwordGroup small').style.display = 'block';
 
-    // блок mailbox скрываем при редактировании
-    document.getElementById('mailboxBlock').style.display = 'none';
+    // При редактировании скрываем блок создания почты
+    document.getElementById('mailboxSection').style.display = 'none';
+    document.getElementById('createMailbox').checked = false;
+    document.getElementById('mailboxFields').style.display = 'none';
 
     document.getElementById('modalOverlay').classList.add('open');
     document.getElementById('fname').focus();
@@ -215,13 +230,10 @@ async function saveEmployee(e) {
     btn.disabled = true;
     btn.textContent = 'Сохранение...';
 
-    const emailLocal = document.getElementById('femail').value.trim();
-    const fullEmail = emailLocal.includes('@') ? emailLocal : `${emailLocal}@serpmonn.ru`;
-
     const body = {
         first_name: document.getElementById('fname').value.trim(),
         last_name:  document.getElementById('lname').value.trim(),
-        email:      fullEmail,
+        email:      document.getElementById('femail').value.trim(),
         role:       document.getElementById('frole').value,
         position:   document.getElementById('fposition').value.trim(),
         status:     document.getElementById('fstatus').value,
@@ -231,18 +243,25 @@ async function saveEmployee(e) {
     const pw = document.getElementById('fpassword').value;
     if (pw) body.password = pw;
 
-    // Проверяем нужно ли создать mailbox
-    const createMailbox = !editingId && document.getElementById('fCreateMailbox').checked;
-    const mailboxPassword = document.getElementById('fMailboxPassword').value;
-    if (createMailbox && mailboxPassword.length < 8) {
-        showAlert('Пароль почтового ящика должен быть минимум 8 символов', 'error');
-        btn.disabled = false;
-        btn.textContent = 'Сохранить';
-        return;
+    // Проверяем нужно ли создать почтовый ящик
+    const needMailbox = !editingId && document.getElementById('createMailbox')?.checked;
+    const mailLocal   = document.getElementById('fmailLocal')?.value.trim();
+    const mailPass    = document.getElementById('fmailPassword')?.value;
+
+    if (needMailbox) {
+        if (!mailLocal) {
+            showAlert('Укажите логин почтового ящика', 'error');
+            btn.disabled = false; btn.textContent = 'Сохранить';
+            return;
+        }
+        if (!mailPass || mailPass.length < 8) {
+            showAlert('Пароль почты — минимум 8 символов', 'error');
+            btn.disabled = false; btn.textContent = 'Сохранить';
+            return;
+        }
     }
 
     try {
-        // 1. Сохраняем сотрудника
         const url = editingId ? `${API}/employees/${editingId}` : `${API}/employees`;
         const method = editingId ? 'PUT' : 'POST';
         const r = await fetch(url, {
@@ -257,32 +276,31 @@ async function saveEmployee(e) {
             throw new Error(err.message || r.statusText);
         }
 
-        // 2. Создаём почтовый ящик если нужно
-        if (createMailbox) {
+        // Создаём почтовый ящик если нужно
+        if (needMailbox) {
             btn.textContent = 'Создание ящика...';
-            const mr = await fetch(`${MAIL_API}/create-mailbox`, {
+            const mr = await fetch(`${API}/mailbox`, {
                 method: 'POST',
                 credentials: 'include',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    email: fullEmail,
-                    password: mailboxPassword,
-                }),
+                body: JSON.stringify({ localPart: mailLocal, password: mailPass }),
             });
             if (!mr.ok) {
                 const merr = await mr.json().catch(() => ({ message: mr.statusText }));
-                // Сотрудник уже создан — предупреждаем, но не считаем критической ошибкой
-                showAlert(`Сотрудник добавлен, но ящик не создан: ${merr.message || mr.statusText}`, 'error');
-                await loadEmployees();
+                // Сотрудник создан, но ящик не создался — показываем предупреждение
                 closeModal();
+                showAlert(`Сотрудник создан, но ящик не создан: ${merr.message}`, 'error');
+                await loadEmployees();
                 return;
             }
-            showAlert(`Сотрудник добавлен, ящик ${fullEmail} создан ✓`, 'success');
+            const mdata = await mr.json();
+            closeModal();
+            showAlert(`Сотрудник добавлен. Ящик ${mdata.email} создан ✓`, 'success');
         } else {
+            closeModal();
             showAlert(editingId ? 'Сотрудник обновлён' : 'Сотрудник добавлен', 'success');
         }
 
-        closeModal();
         await loadEmployees();
     } catch (err) {
         showAlert('Ошибка: ' + err.message, 'error');
@@ -347,43 +365,25 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('searchInput').addEventListener('input', applyFilters);
     document.getElementById('roleFilter').addEventListener('change', applyFilters);
 
-    // Показываем/скрываем поля почтового ящика
-    document.getElementById('fCreateMailbox').addEventListener('change', function() {
+    // Чекбокс почтового ящика
+    document.getElementById('createMailbox').addEventListener('change', function() {
         const fields = document.getElementById('mailboxFields');
-        const pwInput = document.getElementById('fMailboxPassword');
+        fields.style.display = this.checked ? 'block' : 'none';
         if (this.checked) {
-            fields.style.display = 'block';
-            pwInput.required = true;
-        } else {
-            fields.style.display = 'none';
-            pwInput.required = false;
-            pwInput.value = '';
+            // Автозаполняем логин
+            document.getElementById('fmailLocal').dataset.manualEdit = 'false';
+            autoFillMailLocal();
         }
     });
 
-    // Авто-подстановка email из имени/фамилии
-    function autoFillEmail() {
-        if (editingId) return; // только при создании
-        const emailInput = document.getElementById('femail');
-        if (emailInput.value.trim()) return; // не перезаписываем если уже заполнено
-        const fname = document.getElementById('fname').value.trim().toLowerCase();
-        const lname = document.getElementById('lname').value.trim().toLowerCase();
-        if (fname && lname) {
-            // транслитерация простая
-            const tr = s => s.replace(/а/g,'a').replace(/б/g,'b').replace(/в/g,'v')
-                .replace(/г/g,'g').replace(/д/g,'d').replace(/е/g,'e').replace(/ё/g,'e')
-                .replace(/ж/g,'zh').replace(/з/g,'z').replace(/и/g,'i').replace(/й/g,'j')
-                .replace(/к/g,'k').replace(/л/g,'l').replace(/м/g,'m').replace(/н/g,'n')
-                .replace(/о/g,'o').replace(/п/g,'p').replace(/р/g,'r').replace(/с/g,'s')
-                .replace(/т/g,'t').replace(/у/g,'u').replace(/ф/g,'f').replace(/х/g,'h')
-                .replace(/ц/g,'ts').replace(/ч/g,'ch').replace(/ш/g,'sh').replace(/щ/g,'sch')
-                .replace(/ъ/g,'').replace(/ы/g,'y').replace(/ь/g,'').replace(/э/g,'e')
-                .replace(/ю/g,'yu').replace(/я/g,'ya').replace(/[^a-z0-9]/g,'');
-            emailInput.value = `${tr(fname)}.${tr(lname)}`;
-        }
-    }
-    document.getElementById('fname').addEventListener('blur', autoFillEmail);
-    document.getElementById('lname').addEventListener('blur', autoFillEmail);
+    // Автозаполнение логина почты при вводе имени/фамилии
+    document.getElementById('fname').addEventListener('input', autoFillMailLocal);
+    document.getElementById('lname').addEventListener('input', autoFillMailLocal);
+
+    // Если пользователь сам редактирует логин — не перезаписываем
+    document.getElementById('fmailLocal').addEventListener('input', function() {
+        this.dataset.manualEdit = 'true';
+    });
 
     document.getElementById('modalOverlay').addEventListener('click', e => {
         if (e.target === e.currentTarget) closeModal();

--- a/frontend/admin/admin_scripts.js
+++ b/frontend/admin/admin_scripts.js
@@ -2,6 +2,7 @@
 // Токен хранится в httpOnly cookie admin_token — все запросы идут с credentials: 'include'
 
 const API = '/api/admin';
+const MAIL_API = '/mail-api';
 const PER_PAGE = 15;
 
 let allEmployees = [];
@@ -142,6 +143,19 @@ function openCreate() {
     document.getElementById('employeeId').value = '';
     document.getElementById('fpassword').required = true;
     document.querySelector('#passwordGroup small').style.display = 'none';
+
+    // email: разблокируем, сбрасываем
+    document.getElementById('femail').value = '';
+    document.getElementById('femail').readOnly = false;
+    document.getElementById('femailHint').style.display = 'none';
+
+    // блок mailbox показываем только при создании
+    document.getElementById('mailboxBlock').style.display = 'block';
+    document.getElementById('fCreateMailbox').checked = false;
+    document.getElementById('mailboxFields').style.display = 'none';
+    document.getElementById('fMailboxPassword').value = '';
+    document.getElementById('fMailboxPassword').required = false;
+
     document.getElementById('modalOverlay').classList.add('open');
     document.getElementById('fname').focus();
 }
@@ -154,7 +168,13 @@ window.openEdit = function(id) {
     document.getElementById('employeeId').value = id;
     document.getElementById('fname').value = e.first_name || '';
     document.getElementById('lname').value = e.last_name || '';
-    document.getElementById('femail').value = e.email || '';
+
+    // email при редактировании — показываем только локальную часть, блокируем
+    const emailLocal = (e.email || '').replace(/@serpmonn\.ru$/, '');
+    document.getElementById('femail').value = emailLocal;
+    document.getElementById('femail').readOnly = true;
+    document.getElementById('femailHint').style.display = 'block';
+
     document.getElementById('frole').value = e.role || '';
     document.getElementById('fposition').value = e.position || '';
     document.getElementById('fstatus').value = e.status || 'active';
@@ -162,6 +182,10 @@ window.openEdit = function(id) {
     document.getElementById('fpassword').value = '';
     document.getElementById('fpassword').required = false;
     document.querySelector('#passwordGroup small').style.display = 'block';
+
+    // блок mailbox скрываем при редактировании
+    document.getElementById('mailboxBlock').style.display = 'none';
+
     document.getElementById('modalOverlay').classList.add('open');
     document.getElementById('fname').focus();
 };
@@ -191,10 +215,13 @@ async function saveEmployee(e) {
     btn.disabled = true;
     btn.textContent = 'Сохранение...';
 
+    const emailLocal = document.getElementById('femail').value.trim();
+    const fullEmail = emailLocal.includes('@') ? emailLocal : `${emailLocal}@serpmonn.ru`;
+
     const body = {
         first_name: document.getElementById('fname').value.trim(),
         last_name:  document.getElementById('lname').value.trim(),
-        email:      document.getElementById('femail').value.trim(),
+        email:      fullEmail,
         role:       document.getElementById('frole').value,
         position:   document.getElementById('fposition').value.trim(),
         status:     document.getElementById('fstatus').value,
@@ -204,7 +231,18 @@ async function saveEmployee(e) {
     const pw = document.getElementById('fpassword').value;
     if (pw) body.password = pw;
 
+    // Проверяем нужно ли создать mailbox
+    const createMailbox = !editingId && document.getElementById('fCreateMailbox').checked;
+    const mailboxPassword = document.getElementById('fMailboxPassword').value;
+    if (createMailbox && mailboxPassword.length < 8) {
+        showAlert('Пароль почтового ящика должен быть минимум 8 символов', 'error');
+        btn.disabled = false;
+        btn.textContent = 'Сохранить';
+        return;
+    }
+
     try {
+        // 1. Сохраняем сотрудника
         const url = editingId ? `${API}/employees/${editingId}` : `${API}/employees`;
         const method = editingId ? 'PUT' : 'POST';
         const r = await fetch(url, {
@@ -218,8 +256,33 @@ async function saveEmployee(e) {
             const err = await r.json().catch(() => ({ message: r.statusText }));
             throw new Error(err.message || r.statusText);
         }
+
+        // 2. Создаём почтовый ящик если нужно
+        if (createMailbox) {
+            btn.textContent = 'Создание ящика...';
+            const mr = await fetch(`${MAIL_API}/create-mailbox`, {
+                method: 'POST',
+                credentials: 'include',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    email: fullEmail,
+                    password: mailboxPassword,
+                }),
+            });
+            if (!mr.ok) {
+                const merr = await mr.json().catch(() => ({ message: mr.statusText }));
+                // Сотрудник уже создан — предупреждаем, но не считаем критической ошибкой
+                showAlert(`Сотрудник добавлен, но ящик не создан: ${merr.message || mr.statusText}`, 'error');
+                await loadEmployees();
+                closeModal();
+                return;
+            }
+            showAlert(`Сотрудник добавлен, ящик ${fullEmail} создан ✓`, 'success');
+        } else {
+            showAlert(editingId ? 'Сотрудник обновлён' : 'Сотрудник добавлен', 'success');
+        }
+
         closeModal();
-        showAlert(editingId ? 'Сотрудник обновлён' : 'Сотрудник добавлен', 'success');
         await loadEmployees();
     } catch (err) {
         showAlert('Ошибка: ' + err.message, 'error');
@@ -283,6 +346,44 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     document.getElementById('searchInput').addEventListener('input', applyFilters);
     document.getElementById('roleFilter').addEventListener('change', applyFilters);
+
+    // Показываем/скрываем поля почтового ящика
+    document.getElementById('fCreateMailbox').addEventListener('change', function() {
+        const fields = document.getElementById('mailboxFields');
+        const pwInput = document.getElementById('fMailboxPassword');
+        if (this.checked) {
+            fields.style.display = 'block';
+            pwInput.required = true;
+        } else {
+            fields.style.display = 'none';
+            pwInput.required = false;
+            pwInput.value = '';
+        }
+    });
+
+    // Авто-подстановка email из имени/фамилии
+    function autoFillEmail() {
+        if (editingId) return; // только при создании
+        const emailInput = document.getElementById('femail');
+        if (emailInput.value.trim()) return; // не перезаписываем если уже заполнено
+        const fname = document.getElementById('fname').value.trim().toLowerCase();
+        const lname = document.getElementById('lname').value.trim().toLowerCase();
+        if (fname && lname) {
+            // транслитерация простая
+            const tr = s => s.replace(/а/g,'a').replace(/б/g,'b').replace(/в/g,'v')
+                .replace(/г/g,'g').replace(/д/g,'d').replace(/е/g,'e').replace(/ё/g,'e')
+                .replace(/ж/g,'zh').replace(/з/g,'z').replace(/и/g,'i').replace(/й/g,'j')
+                .replace(/к/g,'k').replace(/л/g,'l').replace(/м/g,'m').replace(/н/g,'n')
+                .replace(/о/g,'o').replace(/п/g,'p').replace(/р/g,'r').replace(/с/g,'s')
+                .replace(/т/g,'t').replace(/у/g,'u').replace(/ф/g,'f').replace(/х/g,'h')
+                .replace(/ц/g,'ts').replace(/ч/g,'ch').replace(/ш/g,'sh').replace(/щ/g,'sch')
+                .replace(/ъ/g,'').replace(/ы/g,'y').replace(/ь/g,'').replace(/э/g,'e')
+                .replace(/ю/g,'yu').replace(/я/g,'ya').replace(/[^a-z0-9]/g,'');
+            emailInput.value = `${tr(fname)}.${tr(lname)}`;
+        }
+    }
+    document.getElementById('fname').addEventListener('blur', autoFillEmail);
+    document.getElementById('lname').addEventListener('blur', autoFillEmail);
 
     document.getElementById('modalOverlay').addEventListener('click', e => {
         if (e.target === e.currentTarget) closeModal();

--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -96,7 +96,13 @@
                 </div>
                 <div class="form-group">
                     <label for="femail">Email *</label>
-                    <input type="email" id="femail" placeholder="ivan@serpmonn.ru" required>
+                    <div class="email-input-wrap">
+                        <input type="text" id="femail" placeholder="ivan.ivanov" required
+                               pattern="[a-zA-Z0-9._\-]+"
+                               title="Только латинские буквы, цифры, точка, дефис, подчёркивание">
+                        <span class="email-suffix">@serpmonn.ru</span>
+                    </div>
+                    <small class="hint" id="femailHint" style="display:none">При редактировании email менять нельзя</small>
                 </div>
                 <div class="form-group" id="passwordGroup">
                     <label for="fpassword">Пароль *</label>
@@ -136,6 +142,22 @@
                         <input type="date" id="fhire_date">
                     </div>
                 </div>
+
+                <!-- Блок почтового ящика (только при создании) -->
+                <div class="form-group mailbox-block" id="mailboxBlock">
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="fCreateMailbox">
+                        <span>Создать почтовый ящик <strong>@serpmonn.ru</strong></span>
+                    </label>
+                    <div id="mailboxFields" style="display:none; margin-top:10px">
+                        <div class="form-group">
+                            <label for="fMailboxPassword">Пароль почтового ящика *</label>
+                            <input type="password" id="fMailboxPassword" placeholder="Минимум 8 символов">
+                            <small class="hint">Пароль для входа в почту (Roundcube)</small>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="modal-actions">
                     <button type="button" class="btn btn-outline" id="cancelBtn">Отмена</button>
                     <button type="submit" class="btn btn-primary" id="submitBtn">Сохранить</button>

--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -95,17 +95,11 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="femail">Email *</label>
-                    <div class="email-input-wrap">
-                        <input type="text" id="femail" placeholder="ivan.ivanov" required
-                               pattern="[a-zA-Z0-9._\-]+"
-                               title="Только латинские буквы, цифры, точка, дефис, подчёркивание">
-                        <span class="email-suffix">@serpmonn.ru</span>
-                    </div>
-                    <small class="hint" id="femailHint" style="display:none">При редактировании email менять нельзя</small>
+                    <label for="femail">Email сотрудника *</label>
+                    <input type="email" id="femail" placeholder="ivan@serpmonn.ru" required>
                 </div>
                 <div class="form-group" id="passwordGroup">
-                    <label for="fpassword">Пароль *</label>
+                    <label for="fpassword">Пароль для входа в систему *</label>
                     <input type="password" id="fpassword" placeholder="Минимум 8 символов">
                     <small class="hint" style="display:none">При редактировании оставьте пустым, чтобы не менять</small>
                 </div>
@@ -143,16 +137,27 @@
                     </div>
                 </div>
 
-                <!-- Блок почтового ящика (только при создании) -->
-                <div class="form-group mailbox-block" id="mailboxBlock">
-                    <label class="checkbox-label">
-                        <input type="checkbox" id="fCreateMailbox">
-                        <span>Создать почтовый ящик <strong>@serpmonn.ru</strong></span>
+                <!-- Блок почтового ящика — только при создании -->
+                <div class="form-group mailbox-section" id="mailboxSection" style="display:none;border-top:1px solid #e5e7eb;padding-top:16px;margin-top:4px">
+                    <label class="checkbox-label" style="display:flex;align-items:center;gap:8px;cursor:pointer;font-weight:500">
+                        <input type="checkbox" id="createMailbox" style="width:16px;height:16px;cursor:pointer">
+                        Создать почтовый ящик @serpmonn.ru
                     </label>
-                    <div id="mailboxFields" style="display:none; margin-top:10px">
+                    <div id="mailboxFields" style="display:none;margin-top:12px">
+                        <div class="form-group" style="margin-bottom:12px">
+                            <label for="fmailLocal">Логин почты *</label>
+                            <div style="display:flex;align-items:center;gap:0">
+                                <input type="text" id="fmailLocal" placeholder="ivan.ivanov"
+                                    style="border-radius:6px 0 0 6px;flex:1"
+                                    pattern="[a-zA-Z0-9._%+\-]+"
+                                    title="Только латинские буквы, цифры и символы ._%+-">
+                                <span style="background:#f3f4f6;border:1px solid #d1d5db;border-left:none;padding:8px 12px;border-radius:0 6px 6px 0;color:#6b7280;font-size:14px;white-space:nowrap">@serpmonn.ru</span>
+                            </div>
+                            <small class="hint">Только латинские буквы, цифры и ._%+-</small>
+                        </div>
                         <div class="form-group">
-                            <label for="fMailboxPassword">Пароль почтового ящика *</label>
-                            <input type="password" id="fMailboxPassword" placeholder="Минимум 8 символов">
+                            <label for="fmailPassword">Пароль почты *</label>
+                            <input type="password" id="fmailPassword" placeholder="Минимум 8 символов">
                             <small class="hint">Пароль для входа в почту (Roundcube)</small>
                         </div>
                     </div>


### PR DESCRIPTION
## Что изменилось\n\n### `frontend/admin/index.html`\n- Добавлен блок «Создать почтовый ящик @serpmonn.ru» в форму создания сотрудника\n- Поле логина почты с суффиксом `@serpmonn.ru`\n- Отдельное поле пароля для Roundcube\n- Блок скрыт при редактировании сотрудника\n\n### `frontend/admin/admin_scripts.js`\n- Транслитерация имени/фамилии → автозаполнение логина почты (`Иван Иванов` → `ivan.ivanov`)\n- Валидация полей почты перед отправкой\n- После создания сотрудника делает второй запрос `POST /api/admin/mailbox` с `{ localPart, password }`\n- Умная обработка ошибок: если сотрудник создан, а ящик нет — показывает предупреждение без потери данных сотрудника