### PR TITLE
feat(news): SearXNG+Ollama news generator with cache and personalization

### DIFF
--- a/backend/news/news-feed.sql
+++ b/backend/news/news-feed.sql
@@ -1,0 +1,20 @@
+-- Таблица хранения сгенерированных новостей
+CREATE TABLE IF NOT EXISTS news_feed (
+  id           INT AUTO_INCREMENT PRIMARY KEY,
+  topic_key    VARCHAR(50)   NOT NULL,
+  title        VARCHAR(500)  NOT NULL,
+  body         TEXT          NOT NULL,
+  cover_url    TEXT          NULL,         -- URL картинки из SearXNG
+  sources      JSON          NOT NULL,     -- [{title, url}, ...]
+  generated_at DATETIME      NOT NULL DEFAULT NOW(),
+  INDEX idx_topic   (topic_key),
+  INDEX idx_date    (generated_at)
+);
+
+-- Таблица предпочтений пользователя по темам
+CREATE TABLE IF NOT EXISTS user_news_prefs (
+  user_id    INT           NOT NULL,
+  topic_key  VARCHAR(50)   NOT NULL,
+  weight     FLOAT         NOT NULL DEFAULT 1.0,  -- макс 5.0, повышается по кликам
+  PRIMARY KEY (user_id, topic_key)
+);

--- a/backend/news/news-generator.mjs
+++ b/backend/news/news-generator.mjs
@@ -1,0 +1,239 @@
+import dotenv from 'dotenv';
+import { fetchSearxViaCurl } from '../utils/fetchSearxViaCurl.js';
+import { query as dbQuery } from '../database/config.mjs';
+
+dotenv.config({ path: '/var/www/serpmonn.ru/backend/.env' });
+
+const OLLAMA_URL = 'http://127.0.0.1:11434/api/chat';
+const OLLAMA_MAIN_MODEL = 'serpmonn-ai-search:latest';
+const OLLAMA_FAST_MODEL = 'serpmonn-ai-fast:latest';
+
+// Темы для глобальной новостной ленты
+const NEWS_TOPICS = [
+  { key: 'tech',     label: 'Технологии', query: 'technology news today' },
+  { key: 'ai',       label: 'ИИ',         query: 'artificial intelligence news today' },
+  { key: 'science',  label: 'Наука',      query: 'science discoveries news today' },
+  { key: 'world',    label: 'Мир',        query: 'world news today' },
+  { key: 'russia',   label: 'Россия',     query: 'Россия новости сегодня' },
+  { key: 'space',    label: 'Космос',     query: 'space exploration news today' },
+  { key: 'business', label: 'Бизнес',     query: 'global economy business news today' },
+  { key: 'games',    label: 'Игры',       query: 'gaming news today' },
+  { key: 'health',   label: 'Здоровье',   query: 'health medicine news today' },
+  { key: 'sports',   label: 'Спорт',      query: 'sports news today' },
+];
+
+// In-memory кэш — пользователи читают отсюда, нулевая нагрузка на БД
+let newsCache = new Map(); // topic_key → [{ id, title, body, cover_url, sources, generated_at }]
+let cacheUpdatedAt = null;
+
+export function getNewsCache() {
+  return newsCache;
+}
+
+export function getCacheUpdatedAt() {
+  return cacheUpdatedAt;
+}
+
+export function getAllTopics() {
+  return NEWS_TOPICS;
+}
+
+// Загружаем кэш из БД (при старте сервера и после каждой генерации)
+export async function refreshCache() {
+  try {
+    const rows = await dbQuery(
+      `SELECT id, topic_key, title, body, cover_url, sources, generated_at
+       FROM news_feed
+       ORDER BY generated_at DESC
+       LIMIT 300`
+    );
+
+    const grouped = new Map();
+    for (const row of rows) {
+      if (!grouped.has(row.topic_key)) grouped.set(row.topic_key, []);
+      grouped.get(row.topic_key).push({
+        ...row,
+        sources: typeof row.sources === 'string' ? JSON.parse(row.sources) : row.sources,
+      });
+    }
+
+    newsCache = grouped;
+    cacheUpdatedAt = new Date();
+    console.log(`[News] Кэш обновлён: ${rows.length} новостей по ${grouped.size} темам`);
+  } catch (e) {
+    console.error('[News] Ошибка обновления кэша:', e.message);
+  }
+}
+
+// Вызов Ollama для генерации новостной заметки
+async function callOllamaForNews(webContext, topicLabel) {
+  const body = {
+    model: OLLAMA_MAIN_MODEL,
+    messages: [
+      {
+        role: 'system',
+        content:
+          'Ты редактор новостей. На основе предоставленных данных напиши короткую новостную заметку. ' +
+          'Ответь ТОЛЬКО валидным JSON без лишнего текста, в формате: ' +
+          '{"title":"заголовок до 12 слов","body":"2-3 предложения с фактами"}. ' +
+          'Только факты. Без вводных слов. Язык — русский.',
+      },
+      {
+        role: 'user',
+        content: `ТЕМА: ${topicLabel}\n\nДАННЫЕ ИЗ СЕТИ:\n${webContext}`,
+      },
+    ],
+    stream: false,
+    options: { temperature: 0.3, num_predict: 220 },
+  };
+
+  const res = await fetch(OLLAMA_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) throw new Error(`Ollama HTTP ${res.status}`);
+
+  const data = await res.json();
+  const raw = data.message?.content || '';
+
+  // Вырезаем JSON из ответа (на случай если модель добавила текст вокруг)
+  const match = raw.match(/\{[\s\S]*?\}/);
+  if (!match) throw new Error('Ollama не вернул JSON');
+
+  return JSON.parse(match[0]);
+}
+
+// Резервный вызов на быстрой модели
+async function callOllamaFast(webContext, topicLabel) {
+  const body = {
+    model: OLLAMA_FAST_MODEL,
+    messages: [
+      {
+        role: 'system',
+        content:
+          'Ты редактор новостей. Ответь ТОЛЬКО JSON: {"title":"...","body":"..."}. Язык — русский.',
+      },
+      {
+        role: 'user',
+        content: `ТЕМА: ${topicLabel}\nДАННЫЕ:\n${webContext}`,
+      },
+    ],
+    stream: false,
+    options: { temperature: 0.3, num_predict: 220 },
+  };
+
+  const res = await fetch(OLLAMA_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) throw new Error(`Ollama Fast HTTP ${res.status}`);
+
+  const data = await res.json();
+  const raw = data.message?.content || '';
+  const match = raw.match(/\{[\s\S]*?\}/);
+  if (!match) throw new Error('Ollama Fast не вернул JSON');
+
+  return JSON.parse(match[0]);
+}
+
+// Генерация одной новости по теме
+async function generateOneNews(topic) {
+  // 1. Ищем новости через SearXNG (категория news)
+  const data = await fetchSearxViaCurl(topic.query, 'news');
+  const results = (data.results || []).slice(0, 5);
+
+  if (!results.length) {
+    console.warn(`[News] SearXNG вернул пустой результат для темы: ${topic.key}`);
+    return null;
+  }
+
+  // 2. Картинка — берём первую img_src из результатов
+  const cover_url = results.find(r => r.img_src)?.img_src || null;
+
+  // 3. Источники для отображения
+  const sources = results
+    .filter(r => r.url)
+    .slice(0, 4)
+    .map(r => ({
+      title: r.title || new URL(r.url).hostname.replace('www.', ''),
+      url: r.url,
+    }));
+
+  // 4. Контекст для Ollama
+  const webContext = results
+    .map(r => `Заголовок: ${r.title}\nТекст: ${r.content || r.summary || ''}`.trim())
+    .join('\n\n');
+
+  // 5. Генерируем новость через Ollama (основная → резервная)
+  let newsItem;
+  try {
+    newsItem = await callOllamaForNews(webContext, topic.label);
+  } catch (e) {
+    console.warn(`[News] Основная модель упала (${topic.key}): ${e.message}, пробуем fast...`);
+    try {
+      newsItem = await callOllamaFast(webContext, topic.label);
+    } catch (e2) {
+      console.error(`[News] Обе модели упали для темы ${topic.key}:`, e2.message);
+      return null;
+    }
+  }
+
+  if (!newsItem?.title || !newsItem?.body) {
+    console.warn(`[News] Пустой результат от модели для темы ${topic.key}`);
+    return null;
+  }
+
+  return {
+    topic_key: topic.key,
+    title: newsItem.title,
+    body: newsItem.body,
+    cover_url,
+    sources: JSON.stringify(sources),
+  };
+}
+
+// Основная функция генерации — вызывается по крону
+export async function generateAllNews() {
+  console.log('[News] Начинаем генерацию новостей...');
+  const start = Date.now();
+
+  // Удаляем старые новости (старше 3 дней)
+  try {
+    await dbQuery('DELETE FROM news_feed WHERE generated_at < NOW() - INTERVAL 3 DAY');
+  } catch (e) {
+    console.warn('[News] Ошибка очистки старых новостей:', e.message);
+  }
+
+  // Генерируем по одной теме (не параллельно — щадим сервер и Ollama)
+  let successCount = 0;
+  for (const topic of NEWS_TOPICS) {
+    try {
+      const item = await generateOneNews(topic);
+      if (!item) continue;
+
+      await dbQuery(
+        `INSERT INTO news_feed (topic_key, title, body, cover_url, sources, generated_at)
+         VALUES (?, ?, ?, ?, ?, NOW())`,
+        [item.topic_key, item.title, item.body, item.cover_url, item.sources]
+      );
+
+      successCount++;
+      console.log(`[News] ✓ ${topic.key}: ${item.title.slice(0, 60)}`);
+    } catch (e) {
+      console.error(`[News] Ошибка сохранения новости (${topic.key}):`, e.message);
+    }
+
+    // Пауза между темами — не перегружаем Ollama
+    await new Promise(r => setTimeout(r, 1500));
+  }
+
+  const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+  console.log(`[News] Генерация завершена: ${successCount}/${NEWS_TOPICS.length} новостей за ${elapsed}s`);
+
+  // Обновляем кэш в памяти
+  await refreshCache();
+}

--- a/backend/news/newsController.mjs
+++ b/backend/news/newsController.mjs
@@ -1,33 +1,192 @@
-import RSSParser from 'rss-parser';                                                                                                  // Импортируем RSSParser для парсинга RSS-лент
+import paseto from 'paseto';
+import dotenv from 'dotenv';
+import { query as dbQuery } from '../database/config.mjs';
+import {
+  getNewsCache,
+  getCacheUpdatedAt,
+  getAllTopics,
+  refreshCache,
+  generateAllNews,
+} from './news-generator.mjs';
 
-const parser = new RSSParser();                                                                                                      // Создаем экземпляр RSSParser для парсинга
+dotenv.config({ path: '/var/www/serpmonn.ru/backend/.env' });
+const { V2 } = paseto;
+const secretKey = process.env.SECRET_KEY;
 
-// Функция для получения RSS-ленты
-export const fetchRSSFeed = async (url) => {                                                                                         // Определяем функцию для загрузки RSS-ленты
-    try {                                                                                                                            // Начинаем блок обработки ошибок
-        const feed = await parser.parseURL(url);                                                                                     // Парсим RSS-ленту по указанному URL
-        return feed.items;                                                                                                           // Возвращаем элементы ленты
-    } catch (error) {                                                                                                                // Обрабатываем возможные ошибки
-        console.error(`Ошибка загрузки новостей с ${url}:`, error);                                                                  // Логируем ошибку в консоль
-        return null;                                                                                                                 // Возвращаем null при ошибке
-    }                                                                                                                               
+// Извлекаем user_id из куки (или null для гостя)
+async function getUserIdFromReq(req) {
+  const token = req.cookies?.token;
+  if (!token || !secretKey) return null;
+  try {
+    const payload = await V2.verify(token, secretKey);
+    return payload?.id || null;
+  } catch {
+    return null;
+  }
+}
+
+// Дефолтные предпочтения (для гостей и новых пользователей)
+const DEFAULT_WEIGHTS = {
+  world: 1.0,
+  tech: 1.0,
+  ai: 1.0,
+  science: 1.0,
+  russia: 1.0,
+  space: 1.0,
+  business: 1.0,
+  games: 1.0,
+  health: 1.0,
+  sports: 1.0,
 };
 
-// Контроллер для получения новостей
-export const getNews = async (req, res) => {                                                                                         // Определяем функцию для получения новостей
-    let news = null;                                                                                                                 // Инициализируем переменную для новостей
+// Получаем веса тем пользователя из БД
+async function getUserWeights(userId) {
+  if (!userId) return DEFAULT_WEIGHTS;
 
-    console.log('Пытаемся загрузить новости с RIA...');                                                                              // Логируем попытку загрузки с RIA
-    news = await fetchRSSFeed('https://ria.ru/export/rss2/archive/index.xml');                                                       // Пытаемся загрузить новости с RIA
+  try {
+    const rows = await dbQuery(
+      'SELECT topic_key, weight FROM user_news_prefs WHERE user_id = ?',
+      [userId]
+    );
 
-    if (!news) {                                                                                                                     // Проверяем, получены ли новости
-        console.log('RIA недоступен, переключаемся на Lenta...');                                                                    // Логируем переключение на Lenta
-        news = await fetchRSSFeed('https://lenta.ru/rss');                                                                           // Пытаемся загрузить новости с Lenta
-    }                                                                                                                               
+    if (!rows.length) return DEFAULT_WEIGHTS;
 
-    if (news) {                                                                                                                      // Проверяем, удалось ли получить новости
-        res.json(news);                                                                                                              // Возвращаем новости клиенту
-    } else {                                                                                                                         // Обрабатываем случай, если новости не получены
-        res.status(500).send('Ошибка загрузки новостей');                                                                            // Возвращаем ошибку клиенту
-    }                                                                                                                               
-};
+    const weights = { ...DEFAULT_WEIGHTS };
+    for (const row of rows) {
+      weights[row.topic_key] = row.weight;
+    }
+    return weights;
+  } catch (e) {
+    console.error('[News] Ошибка получения предпочтений:', e.message);
+    return DEFAULT_WEIGHTS;
+  }
+}
+
+// Собираем персонализированную ленту из кэша
+function buildFeed(weights, topicFilter) {
+  const cache = getNewsCache();
+  const feed = [];
+
+  for (const [topicKey, items] of cache.entries()) {
+    // Если задан фильтр по теме — берём только её
+    if (topicFilter && topicFilter !== topicKey) continue;
+
+    const weight = weights[topicKey] || 1.0;
+    // Чем выше вес — тем больше новостей из этой темы показываем
+    const count = Math.max(1, Math.round(3 * weight));
+
+    for (const item of items.slice(0, count)) {
+      feed.push({ ...item, weight });
+    }
+  }
+
+  // Сортируем: сначала любимые темы, внутри — по дате
+  feed.sort((a, b) => {
+    if (b.weight !== a.weight) return b.weight - a.weight;
+    return new Date(b.generated_at) - new Date(a.generated_at);
+  });
+
+  // Убираем вспомогательное поле weight из ответа
+  return feed.map(({ weight, ...item }) => item);
+}
+
+// GET /news — получить ленту новостей
+export async function getNews(req, res) {
+  try {
+    const userId = await getUserIdFromReq(req);
+    const topicFilter = req.query.topic || null;
+    const limit = Math.min(parseInt(req.query.limit) || 20, 100);
+
+    const weights = await getUserWeights(userId);
+    const feed = buildFeed(weights, topicFilter).slice(0, limit);
+
+    return res.json({
+      news: feed,
+      topics: getAllTopics(),
+      updatedAt: getCacheUpdatedAt(),
+    });
+  } catch (e) {
+    console.error('[News] Ошибка getNews:', e.message);
+    return res.status(500).json({ error: 'Ошибка загрузки новостей' });
+  }
+}
+
+// GET /news/topics — список всех тем с метками
+export async function getTopics(req, res) {
+  return res.json({ topics: getAllTopics() });
+}
+
+// GET /news/prefs — предпочтения пользователя
+export async function getPrefs(req, res) {
+  const userId = await getUserIdFromReq(req);
+  if (!userId) return res.json({ prefs: DEFAULT_WEIGHTS });
+
+  const weights = await getUserWeights(userId);
+  return res.json({ prefs: weights });
+}
+
+// POST /news/prefs — сохранить выбранные темы
+export async function savePrefs(req, res) {
+  const userId = await getUserIdFromReq(req);
+  if (!userId) return res.status(401).json({ error: 'Требуется авторизация' });
+
+  const { topics } = req.body; // массив выбранных topic_key
+  if (!Array.isArray(topics)) return res.status(400).json({ error: 'topics должен быть массивом' });
+
+  try {
+    // Удаляем старые предпочтения и вставляем новые
+    await dbQuery('DELETE FROM user_news_prefs WHERE user_id = ?', [userId]);
+
+    if (topics.length) {
+      const allTopicKeys = getAllTopics().map(t => t.key);
+      const validTopics = topics.filter(t => allTopicKeys.includes(t));
+
+      for (const topicKey of validTopics) {
+        await dbQuery(
+          'INSERT INTO user_news_prefs (user_id, topic_key, weight) VALUES (?, ?, 1.0)',
+          [userId, topicKey]
+        );
+      }
+    }
+
+    return res.json({ ok: true });
+  } catch (e) {
+    console.error('[News] Ошибка savePrefs:', e.message);
+    return res.status(500).json({ error: 'Ошибка сохранения' });
+  }
+}
+
+// POST /news/click — трекинг клика, повышаем вес темы
+export async function trackClick(req, res) {
+  const userId = await getUserIdFromReq(req);
+  if (!userId) return res.sendStatus(204); // гостей не трекаем
+
+  const { topicKey } = req.body;
+  const allTopicKeys = getAllTopics().map(t => t.key);
+  if (!topicKey || !allTopicKeys.includes(topicKey)) return res.sendStatus(204);
+
+  try {
+    await dbQuery(
+      `INSERT INTO user_news_prefs (user_id, topic_key, weight)
+       VALUES (?, ?, 1.1)
+       ON DUPLICATE KEY UPDATE weight = LEAST(weight * 1.1, 5.0)`,
+      [userId, topicKey]
+    );
+    return res.sendStatus(204);
+  } catch (e) {
+    console.error('[News] Ошибка trackClick:', e.message);
+    return res.sendStatus(204);
+  }
+}
+
+// POST /news/generate — ручной запуск генерации (только для разработки/тестирования)
+export async function triggerGenerate(req, res) {
+  // Простая защита — только с локального адреса
+  const ip = req.ip || req.connection?.remoteAddress || '';
+  if (!ip.includes('127.0.0.1') && !ip.includes('::1')) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  res.json({ ok: true, message: 'Генерация запущена в фоне' });
+  generateAllNews().catch(e => console.error('[News] Ошибка ручной генерации:', e.message));
+}

--- a/backend/news/newsRoutes.mjs
+++ b/backend/news/newsRoutes.mjs
@@ -1,16 +1,37 @@
-import express from 'express';                                                                                                   // Импортируем Express для создания маршрутов
-import { getNews } from './newsController.mjs';                                                                                  // Импортируем контроллер для получения новостей
+import express from 'express';
+import {
+  getNews,
+  getTopics,
+  getPrefs,
+  savePrefs,
+  trackClick,
+  triggerGenerate,
+} from './newsController.mjs';
 
-const router = express.Router();                                                                                                 // Создаем экземпляр маршрутизатора Express
+const router = express.Router();
 
-router.options('*', (req, res) => {                                                                                              // Определяем обработчик для OPTIONS-запросов
-    res.setHeader('Access-Control-Allow-Origin', 'https://serpmonn.ru');                                                         // Устанавливаем разрешенный источник
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');                                            // Устанавливаем разрешенные методы
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');                                                // Устанавливаем разрешенные заголовки
-    res.setHeader('Access-Control-Allow-Credentials', 'true');                                                                   // Разрешаем отправку cookies
-    res.status(200).end();                                                                                                       // Завершаем запрос с кодом 200
-});
+// Получить ленту новостей (персонализированную)
+// GET /news?topic=tech&limit=20
+router.get('/news', getNews);
 
-router.get('/news', getNews);                                                                                                    // Определяем GET маршрут для получения новостей
+// Получить список всех тем
+// GET /news/topics
+router.get('/news/topics', getTopics);
 
-export default router;                                                                                                           // Экспортируем маршрутизатор для использования в приложении
+// Получить предпочтения пользователя
+// GET /news/prefs
+router.get('/news/prefs', getPrefs);
+
+// Сохранить выбранные темы
+// POST /news/prefs { topics: ['tech', 'ai', 'world'] }
+router.post('/news/prefs', savePrefs);
+
+// Трекинг клика по новости (пассивная персонализация)
+// POST /news/click { topicKey: 'tech' }
+router.post('/news/click', trackClick);
+
+// Ручной запуск генерации (только 127.0.0.1)
+// POST /news/generate
+router.post('/news/generate', triggerGenerate);
+
+export default router;


### PR DESCRIPTION
## Что изменилось

Полная переработка новостной ленты:

- Заменяем RSS (РИА/Lenta) на собственную генерацию через SearXNG + Ollama
- Новости агрегируются со всего мира через все поисковики SearXNG
- Картинки берутся прямо из новостных результатов (img_src)
- In-memory кэш — нулевая нагрузка на БД при чтении
- Персонализация по темам с трекингом кликов

## Файлы

- `backend/news/news-generator.mjs` — генератор новостей (SearXNG + Ollama)
- `backend/news/newsController.mjs` — контроллер с кэшем и персонализацией
- `backend/news/newsRoutes.mjs` — роуты
- `backend/news/news-feed.sql` — схема БД (2 таблицы)

## Что нужно сделать после мержа

1. Выполнить `news-feed.sql` в БД
2. Подключить роуты и cron в `server.mjs`
3. `npm install node-cron`