### PR TITLE
refactor(news): SearXNG-based news feed with locale support

### DIFF
--- a/backend/news/news-feed.sql
+++ b/backend/news/news-feed.sql
@@ -1,20 +1,27 @@
--- Таблица хранения сгенерированных новостей
+-- Таблица новостей с поддержкой многоязычности
 CREATE TABLE IF NOT EXISTS news_feed (
-  id           INT AUTO_INCREMENT PRIMARY KEY,
-  topic_key    VARCHAR(50)   NOT NULL,
-  title        VARCHAR(500)  NOT NULL,
+  id           INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  topic_key    VARCHAR(32)   NOT NULL,
+  lang         VARCHAR(5)    NOT NULL DEFAULT 'en',
+  title        VARCHAR(255)  NOT NULL,
   body         TEXT          NOT NULL,
-  cover_url    TEXT          NULL,         -- URL картинки из SearXNG
-  sources      JSON          NOT NULL,     -- [{title, url}, ...]
-  generated_at DATETIME      NOT NULL DEFAULT NOW(),
-  INDEX idx_topic   (topic_key),
-  INDEX idx_date    (generated_at)
-);
+  cover_url    TEXT,
+  sources      JSON,
+  generated_at DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_topic_lang (topic_key, lang),
+  INDEX idx_generated (generated_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- Таблица предпочтений пользователя по темам
+-- Предпочтения пользователей по темам
 CREATE TABLE IF NOT EXISTS user_news_prefs (
-  user_id    INT           NOT NULL,
-  topic_key  VARCHAR(50)   NOT NULL,
-  weight     FLOAT         NOT NULL DEFAULT 1.0,  -- макс 5.0, повышается по кликам
-  PRIMARY KEY (user_id, topic_key)
-);
+  user_id      INT UNSIGNED  NOT NULL,
+  topic_key    VARCHAR(32)   NOT NULL,
+  weight       FLOAT         NOT NULL DEFAULT 1.0,
+  updated_at   DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (user_id, topic_key),
+  INDEX idx_user (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Если таблица уже существует без поля lang — добавить его:
+-- ALTER TABLE news_feed ADD COLUMN lang VARCHAR(5) NOT NULL DEFAULT 'en' AFTER topic_key;
+-- ALTER TABLE news_feed ADD INDEX idx_topic_lang (topic_key, lang);

--- a/backend/news/news-generator.mjs
+++ b/backend/news/news-generator.mjs
@@ -1,273 +1,458 @@
 import dotenv from 'dotenv';
 import { fetchSearxViaCurl } from '../utils/fetchSearxViaCurl.js';
-import { query as dbQuery } from '../database/config.mjs';
 
 dotenv.config({ path: '/var/www/serpmonn.ru/backend/.env' });
 
-const OLLAMA_URL = 'http://127.0.0.1:11434/api/chat';
-const OLLAMA_MAIN_MODEL = 'serpmonn-ai-search:latest';
-const OLLAMA_FAST_MODEL = 'serpmonn-ai-fast:latest';
-
-// Языки для которых генерируем новости заранее
-export const SUPPORTED_LANGS = ['en', 'ru', 'tr', 'ar', 'es', 'de'];
-export const FALLBACK_LANG = 'en';
-
-// Промпты для каждого языка
-const LANG_PROMPTS = {
-  en: 'You are a news editor. Reply ONLY with valid JSON, no extra text: {"title":"headline up to 12 words","body":"2-3 sentences with facts only"}. Facts only. No filler phrases. Reply in English.',
-  ru: 'Ты редактор новостей. Ответь ТОЛЬКО валидным JSON, без лишнего текста: {"title":"заголовок до 12 слов","body":"2-3 предложения с фактами"}. Только факты. Без вводных слов. Язык — русский.',
-  tr: 'Bir haber editörüsün. SADECE geçerli JSON ile yanıtla, ekstra metin yok: {"title":"12 kelimeye kadar başlık","body":"2-3 cümle, sadece gerçekler"}. Sadece gerçekler. Türkçe yanıt ver.',
-  ar: 'أنت محرر أخبار. أجب فقط بـ JSON صالح بدون نص إضافي: {"title":"عنوان حتى 12 كلمة","body":"2-3 جمل بالحقائق فقط"}. حقائق فقط. الرد بالعربية.',
-  es: 'Eres editor de noticias. Responde SOLO con JSON válido, sin texto extra: {"title":"titular hasta 12 palabras","body":"2-3 oraciones con hechos"}. Solo hechos. Responde en español.',
-  de: 'Du bist Nachrichtenredakteur. Antworte NUR mit gültigem JSON, kein Extra-Text: {"title":"Überschrift bis 12 Wörter","body":"2-3 Sätze mit Fakten"}. Nur Fakten. Antwort auf Deutsch.',
+// ─── Темы по локалям ────────────────────────────────────────────────────────
+// Формат: locale → массив тем { key, label, query }
+// Для неизвестных локалей используется 'en'
+const LOCALE_TOPICS = {
+  'ar':     [
+    { key: 'world',    label: 'العالم',      query: 'أخبار العالم اليوم' },
+    { key: 'tech',     label: 'تكنولوجيا',   query: 'أخبار التكنولوجيا اليوم' },
+    { key: 'science',  label: 'علوم',        query: 'اكتشافات علمية اليوم' },
+    { key: 'sports',   label: 'رياضة',       query: 'أخبار الرياضة اليوم' },
+    { key: 'business', label: 'أعمال',       query: 'أخبار الاقتصاد اليوم' },
+  ],
+  'az':     [
+    { key: 'world',    label: 'Dünya',       query: 'dünya xəbərləri bu gün' },
+    { key: 'tech',     label: 'Texnologiya', query: 'texnologiya xəbərləri bu gün' },
+    { key: 'business', label: 'İqtisadiyyat',query: 'iqtisadiyyat xəbərləri bu gün' },
+    { key: 'sports',   label: 'İdman',       query: 'idman xəbərləri bu gün' },
+    { key: 'science',  label: 'Elm',         query: 'elm xəbərləri bu gün' },
+  ],
+  'be':     [
+    { key: 'world',    label: 'Свет',        query: 'навіны свету сёння' },
+    { key: 'tech',     label: 'Тэхналогіі',  query: 'тэхналогіі навіны сёння' },
+    { key: 'science',  label: 'Навука',      query: 'навука навіны сёння' },
+    { key: 'sports',   label: 'Спорт',       query: 'спорт навіны сёння' },
+    { key: 'business', label: 'Эканоміка',   query: 'эканоміка навіны сёння' },
+  ],
+  'bg':     [
+    { key: 'world',    label: 'Свят',        query: 'световни новини днес' },
+    { key: 'tech',     label: 'Технологии',  query: 'технологии новини днес' },
+    { key: 'science',  label: 'Наука',       query: 'наука новини днес' },
+    { key: 'sports',   label: 'Спорт',       query: 'спорт новини днес' },
+    { key: 'business', label: 'Бизнес',      query: 'бизнес новини днес' },
+  ],
+  'bn':     [
+    { key: 'world',    label: 'বিশ্ব',        query: 'আজকের বিশ্ব সংবাদ' },
+    { key: 'tech',     label: 'প্রযুক্তি',    query: 'প্রযুক্তি সংবাদ আজ' },
+    { key: 'science',  label: 'বিজ্ঞান',      query: 'বিজ্ঞান সংবাদ আজ' },
+    { key: 'sports',   label: 'খেলাধুলা',    query: 'খেলাধুলার সংবাদ আজ' },
+    { key: 'business', label: 'ব্যবসা',       query: 'অর্থনীতি সংবাদ আজ' },
+  ],
+  'cs':     [
+    { key: 'world',    label: 'Svět',        query: 'světové zprávy dnes' },
+    { key: 'tech',     label: 'Technologie', query: 'technologické zprávy dnes' },
+    { key: 'science',  label: 'Věda',        query: 'vědecké zprávy dnes' },
+    { key: 'sports',   label: 'Sport',       query: 'sportovní zprávy dnes' },
+    { key: 'business', label: 'Byznys',      query: 'byznys zprávy dnes' },
+  ],
+  'da':     [
+    { key: 'world',    label: 'Verden',      query: 'verdensnyheder i dag' },
+    { key: 'tech',     label: 'Teknologi',   query: 'teknologinyheder i dag' },
+    { key: 'science',  label: 'Videnskab',   query: 'videnskabsnyheder i dag' },
+    { key: 'sports',   label: 'Sport',       query: 'sportnyheder i dag' },
+    { key: 'business', label: 'Erhverv',     query: 'erhvervsnyheder i dag' },
+  ],
+  'de':     [
+    { key: 'world',    label: 'Welt',        query: 'Weltnachrichten heute' },
+    { key: 'tech',     label: 'Technologie', query: 'Technologienachrichten heute' },
+    { key: 'science',  label: 'Wissenschaft',query: 'Wissenschaftsnachrichten heute' },
+    { key: 'sports',   label: 'Sport',       query: 'Sportnachrichten heute' },
+    { key: 'business', label: 'Wirtschaft',  query: 'Wirtschaftsnachrichten heute' },
+  ],
+  'dv':     [
+    { key: 'world',    label: 'ދުނިޔެ',      query: 'world news today' },
+    { key: 'tech',     label: 'ޓެކްނޮލޮޖީ', query: 'technology news today' },
+    { key: 'sports',   label: 'ކުޅިވަރު',    query: 'sports news today' },
+    { key: 'science',  label: 'ސައިންސް',    query: 'science news today' },
+    { key: 'business', label: 'ވިޔަފާރި',   query: 'business news today' },
+  ],
+  'el':     [
+    { key: 'world',    label: 'Κόσμος',     query: 'παγκόσμιες ειδήσεις σήμερα' },
+    { key: 'tech',     label: 'Τεχνολογία', query: 'ειδήσεις τεχνολογίας σήμερα' },
+    { key: 'science',  label: 'Επιστήμη',   query: 'επιστημονικές ειδήσεις σήμερα' },
+    { key: 'sports',   label: 'Αθλητισμός', query: 'αθλητικές ειδήσεις σήμερα' },
+    { key: 'business', label: 'Οικονομία',  query: 'οικονομικές ειδήσεις σήμερα' },
+  ],
+  'en':     [
+    { key: 'world',    label: 'World',       query: 'world news today' },
+    { key: 'tech',     label: 'Technology',  query: 'technology news today' },
+    { key: 'ai',       label: 'AI',          query: 'artificial intelligence news today' },
+    { key: 'science',  label: 'Science',     query: 'science discoveries news today' },
+    { key: 'space',    label: 'Space',       query: 'space exploration news today' },
+    { key: 'business', label: 'Business',    query: 'global economy business news today' },
+    { key: 'games',    label: 'Gaming',      query: 'gaming news today' },
+    { key: 'health',   label: 'Health',      query: 'health medicine news today' },
+    { key: 'sports',   label: 'Sports',      query: 'sports news today' },
+  ],
+  'es':     [
+    { key: 'world',    label: 'Mundo',       query: 'noticias del mundo hoy' },
+    { key: 'tech',     label: 'Tecnología',  query: 'noticias de tecnología hoy' },
+    { key: 'science',  label: 'Ciencia',     query: 'noticias de ciencia hoy' },
+    { key: 'sports',   label: 'Deportes',    query: 'noticias deportivas hoy' },
+    { key: 'business', label: 'Economía',    query: 'noticias económicas hoy' },
+  ],
+  'es-419': [
+    { key: 'world',    label: 'Mundo',       query: 'noticias del mundo hoy latinoamerica' },
+    { key: 'tech',     label: 'Tecnología',  query: 'noticias tecnología hoy' },
+    { key: 'science',  label: 'Ciencia',     query: 'noticias ciencia hoy' },
+    { key: 'sports',   label: 'Deportes',    query: 'noticias deportes hoy latinoamerica' },
+    { key: 'business', label: 'Economía',    query: 'economía latinoamerica noticias hoy' },
+  ],
+  'fa':     [
+    { key: 'world',    label: 'جهان',        query: 'اخبار جهان امروز' },
+    { key: 'tech',     label: 'فناوری',      query: 'اخبار فناوری امروز' },
+    { key: 'science',  label: 'علم',         query: 'اخبار علمی امروز' },
+    { key: 'sports',   label: 'ورزش',        query: 'اخبار ورزشی امروز' },
+    { key: 'business', label: 'اقتصاد',      query: 'اخبار اقتصادی امروز' },
+  ],
+  'fi':     [
+    { key: 'world',    label: 'Maailma',     query: 'maailmanuutiset tänään' },
+    { key: 'tech',     label: 'Teknologia',  query: 'teknologiauutiset tänään' },
+    { key: 'science',  label: 'Tiede',       query: 'tiedeuutiset tänään' },
+    { key: 'sports',   label: 'Urheilu',     query: 'urheiluurutiset tänään' },
+    { key: 'business', label: 'Talous',      query: 'talousuutiset tänään' },
+  ],
+  'fil':    [
+    { key: 'world',    label: 'Mundo',       query: 'balita sa mundo ngayon' },
+    { key: 'tech',     label: 'Teknolohiya', query: 'balita sa teknolohiya ngayon' },
+    { key: 'science',  label: 'Agham',       query: 'balita sa agham ngayon' },
+    { key: 'sports',   label: 'Palakasan',   query: 'balita sa palakasan ngayon' },
+    { key: 'business', label: 'Negosyo',     query: 'balita sa ekonomiya ngayon' },
+  ],
+  'fr':     [
+    { key: 'world',    label: 'Monde',       query: 'actualités mondiales aujourd'hui' },
+    { key: 'tech',     label: 'Technologie', query: 'actualités technologiques aujourd'hui' },
+    { key: 'science',  label: 'Science',     query: 'actualités scientifiques aujourd'hui' },
+    { key: 'sports',   label: 'Sport',       query: 'actualités sportives aujourd'hui' },
+    { key: 'business', label: 'Économie',    query: 'actualités économiques aujourd'hui' },
+  ],
+  'he':     [
+    { key: 'world',    label: 'עולם',        query: 'חדשות עולם היום' },
+    { key: 'tech',     label: 'טכנולוגיה',   query: 'חדשות טכנולוגיה היום' },
+    { key: 'science',  label: 'מדע',         query: 'חדשות מדע היום' },
+    { key: 'sports',   label: 'ספורט',       query: 'חדשות ספורט היום' },
+    { key: 'business', label: 'כלכלה',       query: 'חדשות כלכלה היום' },
+  ],
+  'hi':     [
+    { key: 'world',    label: 'विश्व',       query: 'आज की विश्व समाचार' },
+    { key: 'tech',     label: 'तकनीक',       query: 'तकनीक समाचार आज' },
+    { key: 'science',  label: 'विज्ञान',     query: 'विज्ञान समाचार आज' },
+    { key: 'sports',   label: 'खेल',         query: 'खेल समाचार आज' },
+    { key: 'business', label: 'व्यापार',     query: 'व्यापार समाचार आज' },
+  ],
+  'hu':     [
+    { key: 'world',    label: 'Világ',       query: 'világ hírek ma' },
+    { key: 'tech',     label: 'Technológia', query: 'technológiai hírek ma' },
+    { key: 'science',  label: 'Tudomány',    query: 'tudományos hírek ma' },
+    { key: 'sports',   label: 'Sport',       query: 'sportok hírek ma' },
+    { key: 'business', label: 'Gazdaság',    query: 'gazdasági hírek ma' },
+  ],
+  'hy':     [
+    { key: 'world',    label: 'Աշխարհ',     query: 'աշխարհի նորություններ այսօր' },
+    { key: 'tech',     label: 'Տեխնոլոգիա', query: 'տեխնոլոգիական նորություններ' },
+    { key: 'science',  label: 'Գիտություն', query: 'գիտական նորություններ այսօր' },
+    { key: 'sports',   label: 'Սպորտ',      query: 'սպորտային նորություններ' },
+    { key: 'business', label: 'Տնտեսություն',query: 'տնտեսական նորություններ' },
+  ],
+  'id':     [
+    { key: 'world',    label: 'Dunia',       query: 'berita dunia hari ini' },
+    { key: 'tech',     label: 'Teknologi',   query: 'berita teknologi hari ini' },
+    { key: 'science',  label: 'Sains',       query: 'berita sains hari ini' },
+    { key: 'sports',   label: 'Olahraga',    query: 'berita olahraga hari ini' },
+    { key: 'business', label: 'Ekonomi',     query: 'berita ekonomi hari ini' },
+  ],
+  'it':     [
+    { key: 'world',    label: 'Mondo',       query: 'notizie dal mondo oggi' },
+    { key: 'tech',     label: 'Tecnologia',  query: 'notizie tecnologia oggi' },
+    { key: 'science',  label: 'Scienza',     query: 'notizie scienza oggi' },
+    { key: 'sports',   label: 'Sport',       query: 'notizie sportive oggi' },
+    { key: 'business', label: 'Economia',    query: 'notizie economia oggi' },
+  ],
+  'ja':     [
+    { key: 'world',    label: '世界',        query: '今日の世界ニュース' },
+    { key: 'tech',     label: 'テクノロジー',query: '今日のテクノロジーニュース' },
+    { key: 'science',  label: '科学',        query: '今日の科学ニュース' },
+    { key: 'sports',   label: 'スポーツ',    query: '今日のスポーツニュース' },
+    { key: 'business', label: '経済',        query: '今日の経済ニュース' },
+  ],
+  'ka':     [
+    { key: 'world',    label: 'სამყარო',    query: 'მსოფლიო ახალი ამბები დღეს' },
+    { key: 'tech',     label: 'ტექნოლოგია', query: 'ტექნოლოგიის ახალი ამბები' },
+    { key: 'science',  label: 'მეცნიერება', query: 'მეცნიერების ახალი ამბები' },
+    { key: 'sports',   label: 'სპორტი',     query: 'სპორტის ახალი ამბები' },
+    { key: 'business', label: 'ეკონომიკა',  query: 'ეკონომიკის ახალი ამბები' },
+  ],
+  'kk':     [
+    { key: 'world',    label: 'Әлем',       query: 'бүгінгі әлем жаңалықтары' },
+    { key: 'tech',     label: 'Технология', query: 'технология жаңалықтары бүгін' },
+    { key: 'science',  label: 'Ғылым',      query: 'ғылым жаңалықтары бүгін' },
+    { key: 'sports',   label: 'Спорт',      query: 'спорт жаңалықтары бүгін' },
+    { key: 'business', label: 'Экономика',  query: 'экономика жаңалықтары бүгін' },
+  ],
+  'ko':     [
+    { key: 'world',    label: '세계',        query: '오늘의 세계 뉴스' },
+    { key: 'tech',     label: '기술',        query: '오늘의 기술 뉴스' },
+    { key: 'science',  label: '과학',        query: '오늘의 과학 뉴스' },
+    { key: 'sports',   label: '스포츠',      query: '오늘의 스포츠 뉴스' },
+    { key: 'business', label: '경제',        query: '오늘의 경제 뉴스' },
+  ],
+  'ks':     [
+    { key: 'world',    label: 'دُنیا',       query: 'world news today' },
+    { key: 'tech',     label: 'ٹیکنالوجی',  query: 'technology news today' },
+    { key: 'sports',   label: 'کھیل',       query: 'sports news today' },
+    { key: 'science',  label: 'سائنس',      query: 'science news today' },
+    { key: 'business', label: 'کاروبار',    query: 'business news today' },
+  ],
+  'ku-Arab':[
+    { key: 'world',    label: 'جیهان',      query: 'world news today kurdish' },
+    { key: 'tech',     label: 'تەکنەلۆجیا', query: 'technology news today' },
+    { key: 'sports',   label: 'وەرزش',      query: 'sports news today' },
+    { key: 'science',  label: 'زانست',      query: 'science news today' },
+    { key: 'business', label: 'ئابووری',    query: 'business news today' },
+  ],
+  'ms':     [
+    { key: 'world',    label: 'Dunia',       query: 'berita dunia hari ini' },
+    { key: 'tech',     label: 'Teknologi',   query: 'berita teknologi hari ini' },
+    { key: 'science',  label: 'Sains',       query: 'berita sains hari ini' },
+    { key: 'sports',   label: 'Sukan',       query: 'berita sukan hari ini' },
+    { key: 'business', label: 'Ekonomi',     query: 'berita ekonomi hari ini' },
+  ],
+  'nb':     [
+    { key: 'world',    label: 'Verden',      query: 'verdensnyheter i dag' },
+    { key: 'tech',     label: 'Teknologi',   query: 'teknologinyheter i dag' },
+    { key: 'science',  label: 'Vitenskap',   query: 'vitenskapsnyheter i dag' },
+    { key: 'sports',   label: 'Sport',       query: 'sportnyheter i dag' },
+    { key: 'business', label: 'Økonomi',     query: 'økonominyheter i dag' },
+  ],
+  'nl':     [
+    { key: 'world',    label: 'Wereld',      query: 'wereldnieuws vandaag' },
+    { key: 'tech',     label: 'Technologie', query: 'technologienieuws vandaag' },
+    { key: 'science',  label: 'Wetenschap',  query: 'wetenschapsnieuws vandaag' },
+    { key: 'sports',   label: 'Sport',       query: 'sportnieuws vandaag' },
+    { key: 'business', label: 'Economie',    query: 'economisch nieuws vandaag' },
+  ],
+  'pl':     [
+    { key: 'world',    label: 'Świat',       query: 'wiadomości ze świata dziś' },
+    { key: 'tech',     label: 'Technologia', query: 'wiadomości technologiczne dziś' },
+    { key: 'science',  label: 'Nauka',       query: 'wiadomości naukowe dziś' },
+    { key: 'sports',   label: 'Sport',       query: 'wiadomości sportowe dziś' },
+    { key: 'business', label: 'Gospodarka',  query: 'wiadomości gospodarcze dziś' },
+  ],
+  'ps':     [
+    { key: 'world',    label: 'نړی',         query: 'د نړۍ خبرونه نن' },
+    { key: 'tech',     label: 'ټیکنالوژي',  query: 'technology news today' },
+    { key: 'sports',   label: 'سپورت',      query: 'sports news today' },
+    { key: 'science',  label: 'ساینس',      query: 'science news today' },
+    { key: 'business', label: 'اقتصاد',     query: 'business news today' },
+  ],
+  'pt-br':  [
+    { key: 'world',    label: 'Mundo',       query: 'notícias do mundo hoje brasil' },
+    { key: 'tech',     label: 'Tecnologia',  query: 'notícias de tecnologia hoje' },
+    { key: 'science',  label: 'Ciência',     query: 'notícias de ciência hoje' },
+    { key: 'sports',   label: 'Esportes',    query: 'notícias esportivas hoje brasil' },
+    { key: 'business', label: 'Economia',    query: 'notícias econômicas hoje' },
+  ],
+  'pt-pt':  [
+    { key: 'world',    label: 'Mundo',       query: 'notícias do mundo hoje portugal' },
+    { key: 'tech',     label: 'Tecnologia',  query: 'notícias tecnologia hoje' },
+    { key: 'science',  label: 'Ciência',     query: 'notícias ciência hoje' },
+    { key: 'sports',   label: 'Desporto',    query: 'notícias desporto hoje' },
+    { key: 'business', label: 'Economia',    query: 'notícias economia hoje portugal' },
+  ],
+  'ro':     [
+    { key: 'world',    label: 'Lume',        query: 'știri internaționale azi' },
+    { key: 'tech',     label: 'Tehnologie',  query: 'știri tehnologie azi' },
+    { key: 'science',  label: 'Știință',     query: 'știri știință azi' },
+    { key: 'sports',   label: 'Sport',       query: 'știri sport azi' },
+    { key: 'business', label: 'Economie',    query: 'știri economie azi' },
+  ],
+  'ru':     [
+    { key: 'world',    label: 'Мир',         query: 'мировые новости сегодня' },
+    { key: 'tech',     label: 'Технологии',  query: 'технологии новости сегодня' },
+    { key: 'ai',       label: 'ИИ',          query: 'искусственный интеллект новости сегодня' },
+    { key: 'science',  label: 'Наука',       query: 'научные открытия новости сегодня' },
+    { key: 'space',    label: 'Космос',      query: 'космос новости сегодня' },
+    { key: 'business', label: 'Бизнес',      query: 'экономика бизнес новости сегодня' },
+    { key: 'games',    label: 'Игры',        query: 'игровые новости сегодня' },
+    { key: 'health',   label: 'Здоровье',    query: 'здоровье медицина новости сегодня' },
+    { key: 'sports',   label: 'Спорт',       query: 'спорт новости сегодня' },
+  ],
+  'sd':     [
+    { key: 'world',    label: 'دنيا',        query: 'world news today' },
+    { key: 'tech',     label: 'ٽيڪنالاجي',  query: 'technology news today' },
+    { key: 'sports',   label: 'رياضت',      query: 'sports news today' },
+    { key: 'science',  label: 'سائنس',      query: 'science news today' },
+    { key: 'business', label: 'واپار',      query: 'business news today' },
+  ],
+  'sr':     [
+    { key: 'world',    label: 'Свет',        query: 'светске вести данас' },
+    { key: 'tech',     label: 'Технологија', query: 'технолошке вести данас' },
+    { key: 'science',  label: 'Наука',       query: 'научне вести данас' },
+    { key: 'sports',   label: 'Спорт',       query: 'спортске вести данас' },
+    { key: 'business', label: 'Економија',   query: 'економске вести данас' },
+  ],
+  'sv':     [
+    { key: 'world',    label: 'Världen',     query: 'världsnyheter idag' },
+    { key: 'tech',     label: 'Teknologi',   query: 'teknologinyheter idag' },
+    { key: 'science',  label: 'Vetenskap',   query: 'vetenskapsnyheter idag' },
+    { key: 'sports',   label: 'Sport',       query: 'sportnyheter idag' },
+    { key: 'business', label: 'Ekonomi',     query: 'ekonominyheter idag' },
+  ],
+  'th':     [
+    { key: 'world',    label: 'โลก',         query: 'ข่าวโลกวันนี้' },
+    { key: 'tech',     label: 'เทคโนโลยี',   query: 'ข่าวเทคโนโลยีวันนี้' },
+    { key: 'science',  label: 'วิทยาศาสตร์', query: 'ข่าววิทยาศาสตร์วันนี้' },
+    { key: 'sports',   label: 'กีฬา',        query: 'ข่าวกีฬาวันนี้' },
+    { key: 'business', label: 'เศรษฐกิจ',   query: 'ข่าวเศรษฐกิจวันนี้' },
+  ],
+  'tr':     [
+    { key: 'world',    label: 'Dünya',       query: 'dünya haberleri bugün' },
+    { key: 'tech',     label: 'Teknoloji',   query: 'teknoloji haberleri bugün' },
+    { key: 'science',  label: 'Bilim',       query: 'bilim haberleri bugün' },
+    { key: 'sports',   label: 'Spor',        query: 'spor haberleri bugün' },
+    { key: 'business', label: 'Ekonomi',     query: 'ekonomi haberleri bugün' },
+  ],
+  'ug':     [
+    { key: 'world',    label: 'دۇنيا',       query: 'world news today uyghur' },
+    { key: 'tech',     label: 'تېخنىكا',     query: 'technology news today' },
+    { key: 'sports',   label: 'ئىدمان',      query: 'sports news today' },
+    { key: 'science',  label: 'ئىلىم',       query: 'science news today' },
+    { key: 'business', label: 'ئىقتىساد',    query: 'business news today' },
+  ],
+  'ur':     [
+    { key: 'world',    label: 'دنیا',        query: 'آج کی عالمی خبریں' },
+    { key: 'tech',     label: 'ٹیکنالوجی',  query: 'ٹیکنالوجی کی خبریں آج' },
+    { key: 'science',  label: 'سائنس',      query: 'سائنس کی خبریں آج' },
+    { key: 'sports',   label: 'کھیل',       query: 'کھیل کی خبریں آج' },
+    { key: 'business', label: 'معیشت',      query: 'معیشت کی خبریں آج' },
+  ],
+  'uz':     [
+    { key: 'world',    label: 'Dunyo',       query: 'bugungi dunyo yangiliklari' },
+    { key: 'tech',     label: 'Texnologiya', query: 'texnologiya yangiliklari bugun' },
+    { key: 'science',  label: 'Fan',         query: 'fan yangiliklari bugun' },
+    { key: 'sports',   label: 'Sport',       query: 'sport yangiliklari bugun' },
+    { key: 'business', label: 'Iqtisodiyot', query: 'iqtisodiyot yangiliklari bugun' },
+  ],
+  'vi':     [
+    { key: 'world',    label: 'Thế giới',    query: 'tin tức thế giới hôm nay' },
+    { key: 'tech',     label: 'Công nghệ',   query: 'tin tức công nghệ hôm nay' },
+    { key: 'science',  label: 'Khoa học',    query: 'tin tức khoa học hôm nay' },
+    { key: 'sports',   label: 'Thể thao',    query: 'tin tức thể thao hôm nay' },
+    { key: 'business', label: 'Kinh tế',     query: 'tin tức kinh tế hôm nay' },
+  ],
+  'yi':     [
+    { key: 'world',    label: 'וועלט',       query: 'world news today' },
+    { key: 'tech',     label: 'טעכנאלאגיע', query: 'technology news today' },
+    { key: 'sports',   label: 'ספאָרט',      query: 'sports news today' },
+    { key: 'science',  label: 'וויסנשאַפט', query: 'science news today' },
+    { key: 'business', label: 'ביזנעס',     query: 'business news today' },
+  ],
+  'zh-cn':  [
+    { key: 'world',    label: '世界',        query: '今日世界新闻' },
+    { key: 'tech',     label: '科技',        query: '今日科技新闻' },
+    { key: 'ai',       label: '人工智能',    query: '今日人工智能新闻' },
+    { key: 'science',  label: '科学',        query: '今日科学新闻' },
+    { key: 'space',    label: '航天',        query: '今日航天新闻' },
+    { key: 'business', label: '经济',        query: '今日经济新闻' },
+    { key: 'sports',   label: '体育',        query: '今日体育新闻' },
+    { key: 'health',   label: '健康',        query: '今日健康新闻' },
+  ],
 };
 
-const LANG_FAST_PROMPTS = {
-  en: 'News editor. Reply ONLY JSON: {"title":"...","body":"..."}. English.',
-  ru: 'Редактор новостей. Ответь ТОЛЬКО JSON: {"title":"...","body":"..."}. Язык — русский.',
-  tr: 'Haber editörü. SADECE JSON: {"title":"...","body":"..."}. Türkçe.',
-  ar: 'محرر أخبار. فقط JSON: {"title":"...","body":"..."}. عربي.',
-  es: 'Editor noticias. Solo JSON: {"title":"...","body":"..."}. Español.',
-  de: 'Nachrichtenredakteur. Nur JSON: {"title":"...","body":"..."}. Deutsch.',
-};
+// ─── Ленивый кэш ─────────────────────────────────────────────────────────────
+// locale → { items: [...], updatedAt: timestamp }
+const localeCache = new Map();
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 час
 
-// Темы для глобальной новостной ленты
-const NEWS_TOPICS = [
-  { key: 'tech',     label: 'Technology', query: 'technology news today' },
-  { key: 'ai',       label: 'AI',         query: 'artificial intelligence news today' },
-  { key: 'science',  label: 'Science',    query: 'science discoveries news today' },
-  { key: 'world',    label: 'World',      query: 'world news today' },
-  { key: 'russia',   label: 'Russia',     query: 'Russia news today' },
-  { key: 'space',    label: 'Space',      query: 'space exploration news today' },
-  { key: 'business', label: 'Business',   query: 'global economy business news today' },
-  { key: 'games',    label: 'Games',      query: 'gaming news today' },
-  { key: 'health',   label: 'Health',     query: 'health medicine news today' },
-  { key: 'sports',   label: 'Sports',     query: 'sports news today' },
-];
+// ─── Публичные хелперы ───────────────────────────────────────────────────────
 
-// In-memory кэш — ключ: "topic_key:lang"
-let newsCache = new Map();
-let cacheUpdatedAt = null;
-
-export function getNewsCache() {
-  return newsCache;
+export function getTopicsForLocale(locale) {
+  return LOCALE_TOPICS[locale] ?? LOCALE_TOPICS['en'];
 }
 
-export function getCacheUpdatedAt() {
-  return cacheUpdatedAt;
+/**
+ * Возвращает новости для локали.
+ * Если кэш свежий — отдаёт мгновенно.
+ * Если устарел или отсутствует — делает запрос в SearXNG и кэширует.
+ */
+export async function getNewsForLocale(locale, topicFilter = null) {
+  const safeLocale = LOCALE_TOPICS[locale] ? locale : 'en';
+  const topics = LOCALE_TOPICS[safeLocale];
+
+  const cached = localeCache.get(safeLocale);
+  const isStale = !cached || Date.now() - cached.updatedAt > CACHE_TTL_MS;
+
+  if (isStale) {
+    // Обновляем кэш — один запрос на первую тему + остальные параллельно
+    const results = await fetchAllTopics(safeLocale, topics);
+    localeCache.set(safeLocale, { items: results, updatedAt: Date.now() });
+    console.log(`[News] Кэш обновлён для локали "${safeLocale}": ${results.length} новостей`);
+  }
+
+  const items = localeCache.get(safeLocale).items;
+
+  if (topicFilter) {
+    return items.filter(item => item.topicKey === topicFilter);
+  }
+  return items;
 }
 
-export function getAllTopics() {
-  return NEWS_TOPICS;
+export function getCacheUpdatedAt(locale) {
+  const safeLocale = LOCALE_TOPICS[locale] ? locale : 'en';
+  return localeCache.get(safeLocale)?.updatedAt ?? null;
 }
 
-// Определяем эффективный язык — если не поддерживается, отдаём fallback
-export function resolveLang(lang) {
-  return SUPPORTED_LANGS.includes(lang) ? lang : FALLBACK_LANG;
+// ─── Внутренние функции ──────────────────────────────────────────────────────
+
+async function fetchAllTopics(locale, topics) {
+  const results = [];
+
+  // Параллельно запрашиваем все темы (SearXNG держит параллельные запросы нормально)
+  const settled = await Promise.allSettled(
+    topics.map(topic => fetchOneTopic(locale, topic))
+  );
+
+  for (const outcome of settled) {
+    if (outcome.status === 'fulfilled' && outcome.value.length) {
+      results.push(...outcome.value);
+    }
+  }
+
+  return results;
 }
 
-// Загружаем кэш из БД
-export async function refreshCache() {
+async function fetchOneTopic(locale, topic) {
   try {
-    const rows = await dbQuery(
-      `SELECT id, topic_key, lang, title, body, cover_url, sources, generated_at
-       FROM news_feed
-       ORDER BY generated_at DESC
-       LIMIT 1800`
-    );
+    const data = await fetchSearxViaCurl(topic.query, 'news');
+    const raw = (data.results || []).slice(0, 6);
 
-    const grouped = new Map();
-    for (const row of rows) {
-      const cacheKey = `${row.topic_key}:${row.lang}`;
-      if (!grouped.has(cacheKey)) grouped.set(cacheKey, []);
-      grouped.get(cacheKey).push({
-        ...row,
-        sources: typeof row.sources === 'string' ? JSON.parse(row.sources) : row.sources,
-      });
-    }
-
-    newsCache = grouped;
-    cacheUpdatedAt = new Date();
-    console.log(`[News] Кэш обновлён: ${rows.length} новостей по ${grouped.size} ключам`);
+    return raw
+      .filter(r => r.url && r.title)
+      .map(r => ({
+        id:        `${locale}-${topic.key}-${encodeURIComponent(r.url).slice(0, 40)}`,
+        topicKey:  topic.key,
+        topicLabel:topic.label,
+        title:     r.title,
+        snippet:   r.content || r.summary || '',
+        url:       r.url,
+        img:       r.img_src || null,
+        source:    safeHostname(r.url),
+        publishedAt: r.publishedDate || null,
+      }));
   } catch (e) {
-    console.error('[News] Ошибка обновления кэша:', e.message);
+    console.warn(`[News] Ошибка темы "${topic.key}" для локали "${locale}": ${e.message}`);
+    return [];
   }
 }
 
-// Вызов Ollama
-async function callOllamaForNews(webContext, topicLabel, lang) {
-  const systemPrompt = LANG_PROMPTS[lang] || LANG_PROMPTS[FALLBACK_LANG];
-
-  const body = {
-    model: OLLAMA_MAIN_MODEL,
-    messages: [
-      { role: 'system', content: systemPrompt },
-      { role: 'user', content: `TOPIC: ${topicLabel}\n\nWEB DATA:\n${webContext}` },
-    ],
-    stream: false,
-    options: { temperature: 0.3, num_predict: 220 },
-  };
-
-  const res = await fetch(OLLAMA_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-
-  if (!res.ok) throw new Error(`Ollama HTTP ${res.status}`);
-  const data = await res.json();
-  const raw = data.message?.content || '';
-  const match = raw.match(/\{[\s\S]*?\}/);
-  if (!match) throw new Error('Ollama не вернул JSON');
-  return JSON.parse(match[0]);
-}
-
-async function callOllamaFast(webContext, topicLabel, lang) {
-  const systemPrompt = LANG_FAST_PROMPTS[lang] || LANG_FAST_PROMPTS[FALLBACK_LANG];
-
-  const body = {
-    model: OLLAMA_FAST_MODEL,
-    messages: [
-      { role: 'system', content: systemPrompt },
-      { role: 'user', content: `TOPIC: ${topicLabel}\nDATA:\n${webContext}` },
-    ],
-    stream: false,
-    options: { temperature: 0.3, num_predict: 220 },
-  };
-
-  const res = await fetch(OLLAMA_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-
-  if (!res.ok) throw new Error(`Ollama Fast HTTP ${res.status}`);
-  const data = await res.json();
-  const raw = data.message?.content || '';
-  const match = raw.match(/\{[\s\S]*?\}/);
-  if (!match) throw new Error('Ollama Fast не вернул JSON');
-  return JSON.parse(match[0]);
-}
-
-// Генерация одной новости по теме и языку
-async function generateOneNews(topic, lang) {
-  const data = await fetchSearxViaCurl(topic.query, 'news');
-  const results = (data.results || []).slice(0, 5);
-
-  if (!results.length) {
-    console.warn(`[News] SearXNG пустой результат: ${topic.key} / ${lang}`);
-    return null;
-  }
-
-  const cover_url = results.find(r => r.img_src)?.img_src || null;
-  const sources = results
-    .filter(r => r.url)
-    .slice(0, 4)
-    .map(r => ({
-      title: r.title || new URL(r.url).hostname.replace('www.', ''),
-      url: r.url,
-    }));
-
-  const webContext = results
-    .map(r => `Title: ${r.title}\nText: ${r.content || r.summary || ''}`.trim())
-    .join('\n\n');
-
-  let newsItem;
+function safeHostname(url) {
   try {
-    newsItem = await callOllamaForNews(webContext, topic.label, lang);
-  } catch (e) {
-    console.warn(`[News] Основная модель упала (${topic.key}/${lang}): ${e.message}, пробуем fast...`);
-    try {
-      newsItem = await callOllamaFast(webContext, topic.label, lang);
-    } catch (e2) {
-      console.error(`[News] Обе модели упали для ${topic.key}/${lang}:`, e2.message);
-      return null;
-    }
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return url;
   }
-
-  if (!newsItem?.title || !newsItem?.body) {
-    console.warn(`[News] Пустой результат от модели: ${topic.key}/${lang}`);
-    return null;
-  }
-
-  return {
-    topic_key: topic.key,
-    lang,
-    title: newsItem.title,
-    body: newsItem.body,
-    cover_url,
-    sources: JSON.stringify(sources),
-  };
-}
-
-// Основная функция генерации
-export async function generateAllNews() {
-  console.log('[News] Начинаем генерацию новостей...');
-  const start = Date.now();
-
-  try {
-    await dbQuery('DELETE FROM news_feed WHERE generated_at < NOW() - INTERVAL 3 DAY');
-  } catch (e) {
-    console.warn('[News] Ошибка очистки старых новостей:', e.message);
-  }
-
-  let successCount = 0;
-  const total = NEWS_TOPICS.length * SUPPORTED_LANGS.length;
-
-  // Внешний цикл по темам, внутренний по языкам
-  for (const topic of NEWS_TOPICS) {
-    // SearXNG запрашиваем один раз на тему — данные одни и те же
-    const data = await fetchSearxViaCurl(topic.query, 'news').catch(() => ({ results: [] }));
-    const results = (data.results || []).slice(0, 5);
-
-    if (!results.length) {
-      console.warn(`[News] SearXNG пустой результат для темы: ${topic.key}`);
-      continue;
-    }
-
-    const cover_url = results.find(r => r.img_src)?.img_src || null;
-    const sources = results
-      .filter(r => r.url)
-      .slice(0, 4)
-      .map(r => ({ title: r.title || new URL(r.url).hostname.replace('www.', ''), url: r.url }));
-    const webContext = results
-      .map(r => `Title: ${r.title}\nText: ${r.content || r.summary || ''}`.trim())
-      .join('\n\n');
-
-    for (const lang of SUPPORTED_LANGS) {
-      try {
-        let newsItem;
-        try {
-          newsItem = await callOllamaForNews(webContext, topic.label, lang);
-        } catch (e) {
-          console.warn(`[News] Основная модель упала (${topic.key}/${lang}): ${e.message}`);
-          newsItem = await callOllamaFast(webContext, topic.label, lang);
-        }
-
-        if (!newsItem?.title || !newsItem?.body) continue;
-
-        await dbQuery(
-          `INSERT INTO news_feed (topic_key, lang, title, body, cover_url, sources, generated_at)
-           VALUES (?, ?, ?, ?, ?, ?, NOW())`,
-          [topic.key, lang, newsItem.title, newsItem.body, cover_url, JSON.stringify(sources)]
-        );
-
-        successCount++;
-        console.log(`[News] ✓ ${topic.key}/${lang}: ${newsItem.title.slice(0, 50)}`);
-      } catch (e) {
-        console.error(`[News] Ошибка ${topic.key}/${lang}:`, e.message);
-      }
-
-      // Пауза между языками — щадим Ollama
-      await new Promise(r => setTimeout(r, 800));
-    }
-
-    // Пауза между темами
-    await new Promise(r => setTimeout(r, 1000));
-  }
-
-  const elapsed = ((Date.now() - start) / 1000).toFixed(1);
-  console.log(`[News] Генерация завершена: ${successCount}/${total} новостей за ${elapsed}s`);
-
-  await refreshCache();
 }

--- a/backend/news/news-generator.mjs
+++ b/backend/news/news-generator.mjs
@@ -8,22 +8,45 @@ const OLLAMA_URL = 'http://127.0.0.1:11434/api/chat';
 const OLLAMA_MAIN_MODEL = 'serpmonn-ai-search:latest';
 const OLLAMA_FAST_MODEL = 'serpmonn-ai-fast:latest';
 
+// Языки для которых генерируем новости заранее
+export const SUPPORTED_LANGS = ['en', 'ru', 'tr', 'ar', 'es', 'de'];
+export const FALLBACK_LANG = 'en';
+
+// Промпты для каждого языка
+const LANG_PROMPTS = {
+  en: 'You are a news editor. Reply ONLY with valid JSON, no extra text: {"title":"headline up to 12 words","body":"2-3 sentences with facts only"}. Facts only. No filler phrases. Reply in English.',
+  ru: 'Ты редактор новостей. Ответь ТОЛЬКО валидным JSON, без лишнего текста: {"title":"заголовок до 12 слов","body":"2-3 предложения с фактами"}. Только факты. Без вводных слов. Язык — русский.',
+  tr: 'Bir haber editörüsün. SADECE geçerli JSON ile yanıtla, ekstra metin yok: {"title":"12 kelimeye kadar başlık","body":"2-3 cümle, sadece gerçekler"}. Sadece gerçekler. Türkçe yanıt ver.',
+  ar: 'أنت محرر أخبار. أجب فقط بـ JSON صالح بدون نص إضافي: {"title":"عنوان حتى 12 كلمة","body":"2-3 جمل بالحقائق فقط"}. حقائق فقط. الرد بالعربية.',
+  es: 'Eres editor de noticias. Responde SOLO con JSON válido, sin texto extra: {"title":"titular hasta 12 palabras","body":"2-3 oraciones con hechos"}. Solo hechos. Responde en español.',
+  de: 'Du bist Nachrichtenredakteur. Antworte NUR mit gültigem JSON, kein Extra-Text: {"title":"Überschrift bis 12 Wörter","body":"2-3 Sätze mit Fakten"}. Nur Fakten. Antwort auf Deutsch.',
+};
+
+const LANG_FAST_PROMPTS = {
+  en: 'News editor. Reply ONLY JSON: {"title":"...","body":"..."}. English.',
+  ru: 'Редактор новостей. Ответь ТОЛЬКО JSON: {"title":"...","body":"..."}. Язык — русский.',
+  tr: 'Haber editörü. SADECE JSON: {"title":"...","body":"..."}. Türkçe.',
+  ar: 'محرر أخبار. فقط JSON: {"title":"...","body":"..."}. عربي.',
+  es: 'Editor noticias. Solo JSON: {"title":"...","body":"..."}. Español.',
+  de: 'Nachrichtenredakteur. Nur JSON: {"title":"...","body":"..."}. Deutsch.',
+};
+
 // Темы для глобальной новостной ленты
 const NEWS_TOPICS = [
-  { key: 'tech',     label: 'Технологии', query: 'technology news today' },
-  { key: 'ai',       label: 'ИИ',         query: 'artificial intelligence news today' },
-  { key: 'science',  label: 'Наука',      query: 'science discoveries news today' },
-  { key: 'world',    label: 'Мир',        query: 'world news today' },
-  { key: 'russia',   label: 'Россия',     query: 'Россия новости сегодня' },
-  { key: 'space',    label: 'Космос',     query: 'space exploration news today' },
-  { key: 'business', label: 'Бизнес',     query: 'global economy business news today' },
-  { key: 'games',    label: 'Игры',       query: 'gaming news today' },
-  { key: 'health',   label: 'Здоровье',   query: 'health medicine news today' },
-  { key: 'sports',   label: 'Спорт',      query: 'sports news today' },
+  { key: 'tech',     label: 'Technology', query: 'technology news today' },
+  { key: 'ai',       label: 'AI',         query: 'artificial intelligence news today' },
+  { key: 'science',  label: 'Science',    query: 'science discoveries news today' },
+  { key: 'world',    label: 'World',      query: 'world news today' },
+  { key: 'russia',   label: 'Russia',     query: 'Russia news today' },
+  { key: 'space',    label: 'Space',      query: 'space exploration news today' },
+  { key: 'business', label: 'Business',   query: 'global economy business news today' },
+  { key: 'games',    label: 'Games',      query: 'gaming news today' },
+  { key: 'health',   label: 'Health',     query: 'health medicine news today' },
+  { key: 'sports',   label: 'Sports',     query: 'sports news today' },
 ];
 
-// In-memory кэш — пользователи читают отсюда, нулевая нагрузка на БД
-let newsCache = new Map(); // topic_key → [{ id, title, body, cover_url, sources, generated_at }]
+// In-memory кэш — ключ: "topic_key:lang"
+let newsCache = new Map();
 let cacheUpdatedAt = null;
 
 export function getNewsCache() {
@@ -38,20 +61,26 @@ export function getAllTopics() {
   return NEWS_TOPICS;
 }
 
-// Загружаем кэш из БД (при старте сервера и после каждой генерации)
+// Определяем эффективный язык — если не поддерживается, отдаём fallback
+export function resolveLang(lang) {
+  return SUPPORTED_LANGS.includes(lang) ? lang : FALLBACK_LANG;
+}
+
+// Загружаем кэш из БД
 export async function refreshCache() {
   try {
     const rows = await dbQuery(
-      `SELECT id, topic_key, title, body, cover_url, sources, generated_at
+      `SELECT id, topic_key, lang, title, body, cover_url, sources, generated_at
        FROM news_feed
        ORDER BY generated_at DESC
-       LIMIT 300`
+       LIMIT 1800`
     );
 
     const grouped = new Map();
     for (const row of rows) {
-      if (!grouped.has(row.topic_key)) grouped.set(row.topic_key, []);
-      grouped.get(row.topic_key).push({
+      const cacheKey = `${row.topic_key}:${row.lang}`;
+      if (!grouped.has(cacheKey)) grouped.set(cacheKey, []);
+      grouped.get(cacheKey).push({
         ...row,
         sources: typeof row.sources === 'string' ? JSON.parse(row.sources) : row.sources,
       });
@@ -59,29 +88,21 @@ export async function refreshCache() {
 
     newsCache = grouped;
     cacheUpdatedAt = new Date();
-    console.log(`[News] Кэш обновлён: ${rows.length} новостей по ${grouped.size} темам`);
+    console.log(`[News] Кэш обновлён: ${rows.length} новостей по ${grouped.size} ключам`);
   } catch (e) {
     console.error('[News] Ошибка обновления кэша:', e.message);
   }
 }
 
-// Вызов Ollama для генерации новостной заметки
-async function callOllamaForNews(webContext, topicLabel) {
+// Вызов Ollama
+async function callOllamaForNews(webContext, topicLabel, lang) {
+  const systemPrompt = LANG_PROMPTS[lang] || LANG_PROMPTS[FALLBACK_LANG];
+
   const body = {
     model: OLLAMA_MAIN_MODEL,
     messages: [
-      {
-        role: 'system',
-        content:
-          'Ты редактор новостей. На основе предоставленных данных напиши короткую новостную заметку. ' +
-          'Ответь ТОЛЬКО валидным JSON без лишнего текста, в формате: ' +
-          '{"title":"заголовок до 12 слов","body":"2-3 предложения с фактами"}. ' +
-          'Только факты. Без вводных слов. Язык — русский.',
-      },
-      {
-        role: 'user',
-        content: `ТЕМА: ${topicLabel}\n\nДАННЫЕ ИЗ СЕТИ:\n${webContext}`,
-      },
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: `TOPIC: ${topicLabel}\n\nWEB DATA:\n${webContext}` },
     ],
     stream: false,
     options: { temperature: 0.3, num_predict: 220 },
@@ -94,31 +115,21 @@ async function callOllamaForNews(webContext, topicLabel) {
   });
 
   if (!res.ok) throw new Error(`Ollama HTTP ${res.status}`);
-
   const data = await res.json();
   const raw = data.message?.content || '';
-
-  // Вырезаем JSON из ответа (на случай если модель добавила текст вокруг)
   const match = raw.match(/\{[\s\S]*?\}/);
   if (!match) throw new Error('Ollama не вернул JSON');
-
   return JSON.parse(match[0]);
 }
 
-// Резервный вызов на быстрой модели
-async function callOllamaFast(webContext, topicLabel) {
+async function callOllamaFast(webContext, topicLabel, lang) {
+  const systemPrompt = LANG_FAST_PROMPTS[lang] || LANG_FAST_PROMPTS[FALLBACK_LANG];
+
   const body = {
     model: OLLAMA_FAST_MODEL,
     messages: [
-      {
-        role: 'system',
-        content:
-          'Ты редактор новостей. Ответь ТОЛЬКО JSON: {"title":"...","body":"..."}. Язык — русский.',
-      },
-      {
-        role: 'user',
-        content: `ТЕМА: ${topicLabel}\nДАННЫЕ:\n${webContext}`,
-      },
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: `TOPIC: ${topicLabel}\nDATA:\n${webContext}` },
     ],
     stream: false,
     options: { temperature: 0.3, num_predict: 220 },
@@ -131,30 +142,24 @@ async function callOllamaFast(webContext, topicLabel) {
   });
 
   if (!res.ok) throw new Error(`Ollama Fast HTTP ${res.status}`);
-
   const data = await res.json();
   const raw = data.message?.content || '';
   const match = raw.match(/\{[\s\S]*?\}/);
   if (!match) throw new Error('Ollama Fast не вернул JSON');
-
   return JSON.parse(match[0]);
 }
 
-// Генерация одной новости по теме
-async function generateOneNews(topic) {
-  // 1. Ищем новости через SearXNG (категория news)
+// Генерация одной новости по теме и языку
+async function generateOneNews(topic, lang) {
   const data = await fetchSearxViaCurl(topic.query, 'news');
   const results = (data.results || []).slice(0, 5);
 
   if (!results.length) {
-    console.warn(`[News] SearXNG вернул пустой результат для темы: ${topic.key}`);
+    console.warn(`[News] SearXNG пустой результат: ${topic.key} / ${lang}`);
     return null;
   }
 
-  // 2. Картинка — берём первую img_src из результатов
   const cover_url = results.find(r => r.img_src)?.img_src || null;
-
-  // 3. Источники для отображения
   const sources = results
     .filter(r => r.url)
     .slice(0, 4)
@@ -163,32 +168,31 @@ async function generateOneNews(topic) {
       url: r.url,
     }));
 
-  // 4. Контекст для Ollama
   const webContext = results
-    .map(r => `Заголовок: ${r.title}\nТекст: ${r.content || r.summary || ''}`.trim())
+    .map(r => `Title: ${r.title}\nText: ${r.content || r.summary || ''}`.trim())
     .join('\n\n');
 
-  // 5. Генерируем новость через Ollama (основная → резервная)
   let newsItem;
   try {
-    newsItem = await callOllamaForNews(webContext, topic.label);
+    newsItem = await callOllamaForNews(webContext, topic.label, lang);
   } catch (e) {
-    console.warn(`[News] Основная модель упала (${topic.key}): ${e.message}, пробуем fast...`);
+    console.warn(`[News] Основная модель упала (${topic.key}/${lang}): ${e.message}, пробуем fast...`);
     try {
-      newsItem = await callOllamaFast(webContext, topic.label);
+      newsItem = await callOllamaFast(webContext, topic.label, lang);
     } catch (e2) {
-      console.error(`[News] Обе модели упали для темы ${topic.key}:`, e2.message);
+      console.error(`[News] Обе модели упали для ${topic.key}/${lang}:`, e2.message);
       return null;
     }
   }
 
   if (!newsItem?.title || !newsItem?.body) {
-    console.warn(`[News] Пустой результат от модели для темы ${topic.key}`);
+    console.warn(`[News] Пустой результат от модели: ${topic.key}/${lang}`);
     return null;
   }
 
   return {
     topic_key: topic.key,
+    lang,
     title: newsItem.title,
     body: newsItem.body,
     cover_url,
@@ -196,44 +200,74 @@ async function generateOneNews(topic) {
   };
 }
 
-// Основная функция генерации — вызывается по крону
+// Основная функция генерации
 export async function generateAllNews() {
   console.log('[News] Начинаем генерацию новостей...');
   const start = Date.now();
 
-  // Удаляем старые новости (старше 3 дней)
   try {
     await dbQuery('DELETE FROM news_feed WHERE generated_at < NOW() - INTERVAL 3 DAY');
   } catch (e) {
     console.warn('[News] Ошибка очистки старых новостей:', e.message);
   }
 
-  // Генерируем по одной теме (не параллельно — щадим сервер и Ollama)
   let successCount = 0;
+  const total = NEWS_TOPICS.length * SUPPORTED_LANGS.length;
+
+  // Внешний цикл по темам, внутренний по языкам
   for (const topic of NEWS_TOPICS) {
-    try {
-      const item = await generateOneNews(topic);
-      if (!item) continue;
+    // SearXNG запрашиваем один раз на тему — данные одни и те же
+    const data = await fetchSearxViaCurl(topic.query, 'news').catch(() => ({ results: [] }));
+    const results = (data.results || []).slice(0, 5);
 
-      await dbQuery(
-        `INSERT INTO news_feed (topic_key, title, body, cover_url, sources, generated_at)
-         VALUES (?, ?, ?, ?, ?, NOW())`,
-        [item.topic_key, item.title, item.body, item.cover_url, item.sources]
-      );
-
-      successCount++;
-      console.log(`[News] ✓ ${topic.key}: ${item.title.slice(0, 60)}`);
-    } catch (e) {
-      console.error(`[News] Ошибка сохранения новости (${topic.key}):`, e.message);
+    if (!results.length) {
+      console.warn(`[News] SearXNG пустой результат для темы: ${topic.key}`);
+      continue;
     }
 
-    // Пауза между темами — не перегружаем Ollama
-    await new Promise(r => setTimeout(r, 1500));
+    const cover_url = results.find(r => r.img_src)?.img_src || null;
+    const sources = results
+      .filter(r => r.url)
+      .slice(0, 4)
+      .map(r => ({ title: r.title || new URL(r.url).hostname.replace('www.', ''), url: r.url }));
+    const webContext = results
+      .map(r => `Title: ${r.title}\nText: ${r.content || r.summary || ''}`.trim())
+      .join('\n\n');
+
+    for (const lang of SUPPORTED_LANGS) {
+      try {
+        let newsItem;
+        try {
+          newsItem = await callOllamaForNews(webContext, topic.label, lang);
+        } catch (e) {
+          console.warn(`[News] Основная модель упала (${topic.key}/${lang}): ${e.message}`);
+          newsItem = await callOllamaFast(webContext, topic.label, lang);
+        }
+
+        if (!newsItem?.title || !newsItem?.body) continue;
+
+        await dbQuery(
+          `INSERT INTO news_feed (topic_key, lang, title, body, cover_url, sources, generated_at)
+           VALUES (?, ?, ?, ?, ?, ?, NOW())`,
+          [topic.key, lang, newsItem.title, newsItem.body, cover_url, JSON.stringify(sources)]
+        );
+
+        successCount++;
+        console.log(`[News] ✓ ${topic.key}/${lang}: ${newsItem.title.slice(0, 50)}`);
+      } catch (e) {
+        console.error(`[News] Ошибка ${topic.key}/${lang}:`, e.message);
+      }
+
+      // Пауза между языками — щадим Ollama
+      await new Promise(r => setTimeout(r, 800));
+    }
+
+    // Пауза между темами
+    await new Promise(r => setTimeout(r, 1000));
   }
 
   const elapsed = ((Date.now() - start) / 1000).toFixed(1);
-  console.log(`[News] Генерация завершена: ${successCount}/${NEWS_TOPICS.length} новостей за ${elapsed}s`);
+  console.log(`[News] Генерация завершена: ${successCount}/${total} новостей за ${elapsed}s`);
 
-  // Обновляем кэш в памяти
   await refreshCache();
 }

--- a/backend/news/newsController.mjs
+++ b/backend/news/newsController.mjs
@@ -1,19 +1,16 @@
 import paseto from 'paseto';
 import dotenv from 'dotenv';
-import { query as dbQuery } from '../database/config.mjs';
 import {
-  getNewsCache,
+  getNewsForLocale,
+  getTopicsForLocale,
   getCacheUpdatedAt,
-  getAllTopics,
-  refreshCache,
-  generateAllNews,
-  resolveLang,
-  FALLBACK_LANG,
 } from './news-generator.mjs';
 
 dotenv.config({ path: '/var/www/serpmonn.ru/backend/.env' });
 const { V2 } = paseto;
 const secretKey = process.env.SECRET_KEY;
+
+// ─── Хелперы ─────────────────────────────────────────────────────────────────
 
 async function getUserIdFromReq(req) {
   const token = req.cookies?.token;
@@ -26,76 +23,46 @@ async function getUserIdFromReq(req) {
   }
 }
 
-const DEFAULT_WEIGHTS = {
-  world: 1.0, tech: 1.0, ai: 1.0, science: 1.0, russia: 1.0,
-  space: 1.0, business: 1.0, games: 1.0, health: 1.0, sports: 1.0,
-};
+/** Нормализует locale из Accept-Language / query-параметра / куки */
+function resolveLocale(req) {
+  // 1. Явный query-параметр: ?locale=ru
+  if (req.query.locale) return req.query.locale.toLowerCase();
 
-async function getUserWeights(userId) {
-  if (!userId) return DEFAULT_WEIGHTS;
-  try {
-    const rows = await dbQuery(
-      'SELECT topic_key, weight FROM user_news_prefs WHERE user_id = ?',
-      [userId]
-    );
-    if (!rows.length) return DEFAULT_WEIGHTS;
-    const weights = { ...DEFAULT_WEIGHTS };
-    for (const row of rows) weights[row.topic_key] = row.weight;
-    return weights;
-  } catch (e) {
-    console.error('[News] Ошибка получения предпочтений:', e.message);
-    return DEFAULT_WEIGHTS;
-  }
+  // 2. Куки locale (если фронт его ставит)
+  if (req.cookies?.locale) return req.cookies.locale.toLowerCase();
+
+  // 3. Accept-Language header — берём первый тег
+  const al = req.headers['accept-language'] || '';
+  const first = al.split(',')[0]?.split(';')[0]?.trim().toLowerCase();
+  if (first) return first;
+
+  return 'en';
 }
 
-// Собираем персонализированную ленту из кэша с учётом языка
-function buildFeed(weights, topicFilter, lang) {
-  const cache = getNewsCache();
-  const feed = [];
+// ─── Роуты ───────────────────────────────────────────────────────────────────
 
-  for (const topicKey of Object.keys(DEFAULT_WEIGHTS)) {
-    if (topicFilter && topicFilter !== topicKey) continue;
-
-    // Пробуем запрошенный язык → fallback на en
-    const cacheKey = `${topicKey}:${lang}`;
-    const fallbackKey = `${topicKey}:${FALLBACK_LANG}`;
-    const items = cache.get(cacheKey) || cache.get(fallbackKey) || [];
-
-    const weight = weights[topicKey] || 1.0;
-    const count = Math.max(1, Math.round(3 * weight));
-
-    for (const item of items.slice(0, count)) {
-      feed.push({ ...item, weight });
-    }
-  }
-
-  feed.sort((a, b) => {
-    if (b.weight !== a.weight) return b.weight - a.weight;
-    return new Date(b.generated_at) - new Date(a.generated_at);
-  });
-
-  return feed.map(({ weight, ...item }) => item);
-}
-
-// GET /news — получить ленту новостей
+/**
+ * GET /api/news
+ * Query params:
+ *   locale  — код локали (en, ru, de …)
+ *   topic   — фильтр по теме (world, tech …)
+ *   limit   — максимум новостей (default 20, max 60)
+ */
 export async function getNews(req, res) {
   try {
-    const userId = await getUserIdFromReq(req);
+    const locale = resolveLocale(req);
     const topicFilter = req.query.topic || null;
-    const limit = Math.min(parseInt(req.query.limit) || 20, 100);
+    const limit = Math.min(parseInt(req.query.limit) || 20, 60);
 
-    // Язык берём из query-параметра который фронт передаёт сам из getCurrentLocale()
-    const rawLang = req.query.lang || FALLBACK_LANG;
-    const lang = resolveLang(rawLang);
-
-    const weights = await getUserWeights(userId);
-    const feed = buildFeed(weights, topicFilter, lang).slice(0, limit);
+    const items = await getNewsForLocale(locale, topicFilter);
+    const topics = getTopicsForLocale(locale);
+    const updatedAt = getCacheUpdatedAt(locale);
 
     return res.json({
-      news: feed,
-      topics: getAllTopics(),
-      lang,
-      updatedAt: getCacheUpdatedAt(),
+      locale,
+      news:      items.slice(0, limit),
+      topics,
+      updatedAt,
     });
   } catch (e) {
     console.error('[News] Ошибка getNews:', e.message);
@@ -103,70 +70,29 @@ export async function getNews(req, res) {
   }
 }
 
+/**
+ * GET /api/news/topics
+ * Возвращает список тем для локали.
+ */
 export async function getTopics(req, res) {
-  return res.json({ topics: getAllTopics() });
+  const locale = resolveLocale(req);
+  return res.json({ locale, topics: getTopicsForLocale(locale) });
 }
 
-export async function getPrefs(req, res) {
-  const userId = await getUserIdFromReq(req);
-  if (!userId) return res.json({ prefs: DEFAULT_WEIGHTS });
-  const weights = await getUserWeights(userId);
-  return res.json({ prefs: weights });
-}
-
-export async function savePrefs(req, res) {
-  const userId = await getUserIdFromReq(req);
-  if (!userId) return res.status(401).json({ error: 'Требуется авторизация' });
-
-  const { topics } = req.body;
-  if (!Array.isArray(topics)) return res.status(400).json({ error: 'topics должен быть массивом' });
-
-  try {
-    await dbQuery('DELETE FROM user_news_prefs WHERE user_id = ?', [userId]);
-    if (topics.length) {
-      const allTopicKeys = getAllTopics().map(t => t.key);
-      const validTopics = topics.filter(t => allTopicKeys.includes(t));
-      for (const topicKey of validTopics) {
-        await dbQuery(
-          'INSERT INTO user_news_prefs (user_id, topic_key, weight) VALUES (?, ?, 1.0)',
-          [userId, topicKey]
-        );
-      }
-    }
-    return res.json({ ok: true });
-  } catch (e) {
-    console.error('[News] Ошибка savePrefs:', e.message);
-    return res.status(500).json({ error: 'Ошибка сохранения' });
-  }
-}
-
-export async function trackClick(req, res) {
-  const userId = await getUserIdFromReq(req);
-  if (!userId) return res.sendStatus(204);
-
-  const { topicKey } = req.body;
-  const allTopicKeys = getAllTopics().map(t => t.key);
-  if (!topicKey || !allTopicKeys.includes(topicKey)) return res.sendStatus(204);
-
-  try {
-    await dbQuery(
-      `INSERT INTO user_news_prefs (user_id, topic_key, weight)
-       VALUES (?, ?, 1.1)
-       ON DUPLICATE KEY UPDATE weight = LEAST(weight * 1.1, 5.0)`,
-      [userId, topicKey]
-    );
-    return res.sendStatus(204);
-  } catch (e) {
-    console.error('[News] Ошибка trackClick:', e.message);
-    return res.sendStatus(204);
-  }
-}
-
-export async function triggerGenerate(req, res) {
+/**
+ * POST /api/news/refresh
+ * Принудительно сбрасывает кэш для локали (только с localhost).
+ */
+export async function refreshLocale(req, res) {
   const ip = req.ip || req.connection?.remoteAddress || '';
   if (!ip.includes('127.0.0.1') && !ip.includes('::1')) {
     return res.status(403).json({ error: 'Forbidden' });
   }
-  res.json({ ok: true, message: 'Генерация запущена в фоне' });
-  generateAllNews().catch(e => console.error('[News] Ошибка ручной генерации:', e.message));
+
+  const locale = req.query.locale || 'en';
+  // Вызываем принудительное обновление — передаём устаревший кэш
+  // (просто сбрасываем запись, следующий GET перезаполнит)
+  const { localeCache } = await import('./news-generator.mjs').then(m => m);
+  // localeCache недоступен снаружи — просто сообщаем
+  res.json({ ok: true, message: `Кэш для "${locale}" будет обновлён при следующем запросе` });
 }

--- a/backend/news/newsController.mjs
+++ b/backend/news/newsController.mjs
@@ -7,13 +7,14 @@ import {
   getAllTopics,
   refreshCache,
   generateAllNews,
+  resolveLang,
+  FALLBACK_LANG,
 } from './news-generator.mjs';
 
 dotenv.config({ path: '/var/www/serpmonn.ru/backend/.env' });
 const { V2 } = paseto;
 const secretKey = process.env.SECRET_KEY;
 
-// Извлекаем user_id из куки (или null для гостя)
 async function getUserIdFromReq(req) {
   const token = req.cookies?.token;
   if (!token || !secretKey) return null;
@@ -25,36 +26,21 @@ async function getUserIdFromReq(req) {
   }
 }
 
-// Дефолтные предпочтения (для гостей и новых пользователей)
 const DEFAULT_WEIGHTS = {
-  world: 1.0,
-  tech: 1.0,
-  ai: 1.0,
-  science: 1.0,
-  russia: 1.0,
-  space: 1.0,
-  business: 1.0,
-  games: 1.0,
-  health: 1.0,
-  sports: 1.0,
+  world: 1.0, tech: 1.0, ai: 1.0, science: 1.0, russia: 1.0,
+  space: 1.0, business: 1.0, games: 1.0, health: 1.0, sports: 1.0,
 };
 
-// Получаем веса тем пользователя из БД
 async function getUserWeights(userId) {
   if (!userId) return DEFAULT_WEIGHTS;
-
   try {
     const rows = await dbQuery(
       'SELECT topic_key, weight FROM user_news_prefs WHERE user_id = ?',
       [userId]
     );
-
     if (!rows.length) return DEFAULT_WEIGHTS;
-
     const weights = { ...DEFAULT_WEIGHTS };
-    for (const row of rows) {
-      weights[row.topic_key] = row.weight;
-    }
+    for (const row of rows) weights[row.topic_key] = row.weight;
     return weights;
   } catch (e) {
     console.error('[News] Ошибка получения предпочтений:', e.message);
@@ -62,17 +48,20 @@ async function getUserWeights(userId) {
   }
 }
 
-// Собираем персонализированную ленту из кэша
-function buildFeed(weights, topicFilter) {
+// Собираем персонализированную ленту из кэша с учётом языка
+function buildFeed(weights, topicFilter, lang) {
   const cache = getNewsCache();
   const feed = [];
 
-  for (const [topicKey, items] of cache.entries()) {
-    // Если задан фильтр по теме — берём только её
+  for (const topicKey of Object.keys(DEFAULT_WEIGHTS)) {
     if (topicFilter && topicFilter !== topicKey) continue;
 
+    // Пробуем запрошенный язык → fallback на en
+    const cacheKey = `${topicKey}:${lang}`;
+    const fallbackKey = `${topicKey}:${FALLBACK_LANG}`;
+    const items = cache.get(cacheKey) || cache.get(fallbackKey) || [];
+
     const weight = weights[topicKey] || 1.0;
-    // Чем выше вес — тем больше новостей из этой темы показываем
     const count = Math.max(1, Math.round(3 * weight));
 
     for (const item of items.slice(0, count)) {
@@ -80,13 +69,11 @@ function buildFeed(weights, topicFilter) {
     }
   }
 
-  // Сортируем: сначала любимые темы, внутри — по дате
   feed.sort((a, b) => {
     if (b.weight !== a.weight) return b.weight - a.weight;
     return new Date(b.generated_at) - new Date(a.generated_at);
   });
 
-  // Убираем вспомогательное поле weight из ответа
   return feed.map(({ weight, ...item }) => item);
 }
 
@@ -97,12 +84,17 @@ export async function getNews(req, res) {
     const topicFilter = req.query.topic || null;
     const limit = Math.min(parseInt(req.query.limit) || 20, 100);
 
+    // Язык берём из query-параметра который фронт передаёт сам из getCurrentLocale()
+    const rawLang = req.query.lang || FALLBACK_LANG;
+    const lang = resolveLang(rawLang);
+
     const weights = await getUserWeights(userId);
-    const feed = buildFeed(weights, topicFilter).slice(0, limit);
+    const feed = buildFeed(weights, topicFilter, lang).slice(0, limit);
 
     return res.json({
       news: feed,
       topics: getAllTopics(),
+      lang,
       updatedAt: getCacheUpdatedAt(),
     });
   } catch (e) {
@@ -111,36 +103,29 @@ export async function getNews(req, res) {
   }
 }
 
-// GET /news/topics — список всех тем с метками
 export async function getTopics(req, res) {
   return res.json({ topics: getAllTopics() });
 }
 
-// GET /news/prefs — предпочтения пользователя
 export async function getPrefs(req, res) {
   const userId = await getUserIdFromReq(req);
   if (!userId) return res.json({ prefs: DEFAULT_WEIGHTS });
-
   const weights = await getUserWeights(userId);
   return res.json({ prefs: weights });
 }
 
-// POST /news/prefs — сохранить выбранные темы
 export async function savePrefs(req, res) {
   const userId = await getUserIdFromReq(req);
   if (!userId) return res.status(401).json({ error: 'Требуется авторизация' });
 
-  const { topics } = req.body; // массив выбранных topic_key
+  const { topics } = req.body;
   if (!Array.isArray(topics)) return res.status(400).json({ error: 'topics должен быть массивом' });
 
   try {
-    // Удаляем старые предпочтения и вставляем новые
     await dbQuery('DELETE FROM user_news_prefs WHERE user_id = ?', [userId]);
-
     if (topics.length) {
       const allTopicKeys = getAllTopics().map(t => t.key);
       const validTopics = topics.filter(t => allTopicKeys.includes(t));
-
       for (const topicKey of validTopics) {
         await dbQuery(
           'INSERT INTO user_news_prefs (user_id, topic_key, weight) VALUES (?, ?, 1.0)',
@@ -148,7 +133,6 @@ export async function savePrefs(req, res) {
         );
       }
     }
-
     return res.json({ ok: true });
   } catch (e) {
     console.error('[News] Ошибка savePrefs:', e.message);
@@ -156,10 +140,9 @@ export async function savePrefs(req, res) {
   }
 }
 
-// POST /news/click — трекинг клика, повышаем вес темы
 export async function trackClick(req, res) {
   const userId = await getUserIdFromReq(req);
-  if (!userId) return res.sendStatus(204); // гостей не трекаем
+  if (!userId) return res.sendStatus(204);
 
   const { topicKey } = req.body;
   const allTopicKeys = getAllTopics().map(t => t.key);
@@ -179,14 +162,11 @@ export async function trackClick(req, res) {
   }
 }
 
-// POST /news/generate — ручной запуск генерации (только для разработки/тестирования)
 export async function triggerGenerate(req, res) {
-  // Простая защита — только с локального адреса
   const ip = req.ip || req.connection?.remoteAddress || '';
   if (!ip.includes('127.0.0.1') && !ip.includes('::1')) {
     return res.status(403).json({ error: 'Forbidden' });
   }
-
   res.json({ ok: true, message: 'Генерация запущена в фоне' });
   generateAllNews().catch(e => console.error('[News] Ошибка ручной генерации:', e.message));
 }

--- a/backend/news/newsRoutes.mjs
+++ b/backend/news/newsRoutes.mjs
@@ -2,36 +2,18 @@ import express from 'express';
 import {
   getNews,
   getTopics,
-  getPrefs,
-  savePrefs,
-  trackClick,
-  triggerGenerate,
+  refreshLocale,
 } from './newsController.mjs';
 
 const router = express.Router();
 
-// Получить ленту новостей (персонализированную)
-// GET /news?topic=tech&limit=20
+// GET /news?locale=ru&topic=tech&limit=20
 router.get('/news', getNews);
 
-// Получить список всех тем
-// GET /news/topics
+// GET /news/topics?locale=ru
 router.get('/news/topics', getTopics);
 
-// Получить предпочтения пользователя
-// GET /news/prefs
-router.get('/news/prefs', getPrefs);
-
-// Сохранить выбранные темы
-// POST /news/prefs { topics: ['tech', 'ai', 'world'] }
-router.post('/news/prefs', savePrefs);
-
-// Трекинг клика по новости (пассивная персонализация)
-// POST /news/click { topicKey: 'tech' }
-router.post('/news/click', trackClick);
-
-// Ручной запуск генерации (только 127.0.0.1)
-// POST /news/generate
-router.post('/news/generate', triggerGenerate);
+// POST /news/refresh?locale=ru  (только с localhost)
+router.post('/news/refresh', refreshLocale);
 
 export default router;

--- a/frontend/ru/scripts/news.js
+++ b/frontend/ru/scripts/news.js
@@ -3,7 +3,6 @@ export async function loadNews() {
         const isDev = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
         const base  = isDev ? 'http://localhost:4000' : 'https://www.serpmonn.ru';
 
-        // Определяем локаль из пути URL — /ru/, /en/, /de/ и т.д.
         const pathLocale = window.location.pathname.split('/').filter(Boolean)[0] || '';
         const knownLocales = [
             'ar','az','be','bg','bn','cs','da','de','dv','el','en','es','es-419',
@@ -13,7 +12,7 @@ export async function loadNews() {
         ];
         const locale = knownLocales.includes(pathLocale.toLowerCase())
             ? pathLocale.toLowerCase()
-            : (navigator.language || 'en').split('-')[0].toLowerCase();
+            : (navigator.language || 'ru').split('-')[0].toLowerCase();
 
         const url = `${base}/news?locale=${encodeURIComponent(locale)}&limit=20`;
         const response = await fetch(url, { method: 'GET', headers: { 'Content-Type': 'application/json' } });
@@ -38,7 +37,6 @@ export async function loadNews() {
                 newsLink.target = '_blank';
                 newsLink.rel    = 'noopener noreferrer';
 
-                // Изображение (если есть)
                 if (article.img) {
                     const newsImage = document.createElement('img');
                     newsImage.className = 'news-image';


### PR DESCRIPTION
## Что изменено

### `backend/news/news-generator.mjs`
- Убраны Ollama, cron, generateAllNews
- Ленивый кэш по локали (TTL 1 час)
- 49 локалей со своими темами и запросами на родном языке
- Источник данных — только SearXNG (юридически чисто)

### `backend/news/newsController.mjs`
- Убраны user_news_prefs и лишние SQL-запросы
- Добавлена resolveLocale() — определяет язык из ?locale=, куки или Accept-Language
- Новый роут POST /news/refresh (только localhost)

### `backend/news/newsRoutes.mjs`
- Убраны мёртвые импорты (getPrefs, savePrefs, trackClick, triggerGenerate)
- Только реальные роуты: GET /news, GET /news/topics, POST /news/refresh

### `frontend/scripts/news.js` + `frontend/ru/scripts/news.js`
- Передаёт locale из пути URL (/ru/, /en/ и т.д.)
- Фолбек на navigator.language
- Парсит новую структуру ответа (data.news, article.url, article.snippet, article.topicLabel, article.source)