### PR TITLE
feat: add SVG icons for typing and rat games

### DIFF
--- a/frontend/images/rat.svg
+++ b/frontend/images/rat.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="24" fill="#1a1a2e"/>
+  <!-- Body -->
+  <ellipse cx="105" cy="120" rx="45" ry="35" fill="#8b7355"/>
+  <!-- Head -->
+  <circle cx="70" cy="100" r="28" fill="#8b7355"/>
+  <!-- Ears -->
+  <circle cx="55" cy="75" r="14" fill="#c9a87c"/>
+  <circle cx="55" cy="75" r="9" fill="#e8b4b8"/>
+  <circle cx="80" cy="70" r="12" fill="#c9a87c"/>
+  <circle cx="80" cy="70" r="7" fill="#e8b4b8"/>
+  <!-- Eyes -->
+  <circle cx="62" cy="97" r="6" fill="#1a1a2e"/>
+  <circle cx="62" cy="97" r="4" fill="#e8b4b8"/>
+  <circle cx="63" cy="96" r="1.5" fill="white"/>
+  <!-- Nose -->
+  <ellipse cx="48" cy="104" rx="5" ry="4" fill="#c9a87c"/>
+  <circle cx="48" cy="103" r="2.5" fill="#e8b4b8"/>
+  <!-- Whiskers -->
+  <line x1="43" y1="101" x2="22" y2="95" stroke="#c9a87c" stroke-width="1.2" stroke-linecap="round"/>
+  <line x1="43" y1="104" x2="20" y2="104" stroke="#c9a87c" stroke-width="1.2" stroke-linecap="round"/>
+  <line x1="43" y1="107" x2="22" y2="113" stroke="#c9a87c" stroke-width="1.2" stroke-linecap="round"/>
+  <line x1="53" y1="101" x2="62" y2="90" stroke="#c9a87c" stroke-width="1" stroke-linecap="round" opacity="0.5"/>
+  <!-- Tail -->
+  <path d="M148 130 Q175 120 178 140 Q180 158 165 155" fill="none" stroke="#c9a87c" stroke-width="4" stroke-linecap="round"/>
+  <!-- Feet -->
+  <ellipse cx="85" cy="150" rx="12" ry="7" fill="#6b5a3e"/>
+  <ellipse cx="110" cy="152" rx="12" ry="7" fill="#6b5a3e"/>
+  <ellipse cx="130" cy="148" rx="12" ry="7" fill="#6b5a3e"/>
+  <!-- Cheese (small) -->
+  <polygon points="155,75 175,75 165,55" fill="#f4c430"/>
+  <polygon points="155,75 175,75 165,55" fill="none" stroke="#e6b800" stroke-width="1"/>
+  <circle cx="163" cy="70" r="3" fill="#e6a800" opacity="0.7"/>
+  <circle cx="170" cy="73" r="2" fill="#e6a800" opacity="0.7"/>
+</svg>

--- a/frontend/images/typing.svg
+++ b/frontend/images/typing.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="24" fill="#1a1a2e"/>
+  <!-- Keyboard body -->
+  <rect x="20" y="80" width="160" height="90" rx="12" fill="#16213e"/>
+  <rect x="20" y="80" width="160" height="90" rx="12" fill="none" stroke="#4f98a3" stroke-width="2"/>
+  <!-- Row 1 keys -->
+  <rect x="30" y="90" width="18" height="16" rx="4" fill="#0f3460"/>
+  <rect x="52" y="90" width="18" height="16" rx="4" fill="#0f3460"/>
+  <rect x="74" y="90" width="18" height="16" rx="4" fill="#0f3460"/>
+  <rect x="96" y="90" width="18" height="16" rx="4" fill="#0f3460"/>
+  <rect x="118" y="90" width="18" height="16" rx="4" fill="#0f3460"/>
+  <rect x="140" y="90" width="18" height="16" rx="4" fill="#4f98a3"/>
+  <!-- Row 2 keys -->
+  <rect x="35" y="112" width="18" height="16" rx="4" fill="#0f3460"/>
+  <rect x="57" y="112" width="18" height="16" rx="4" fill="#4f98a3"/>
+  <rect x="79" y="112" width="18" height="16" rx="4" fill="#0f3460"/>
+  <rect x="101" y="112" width="18" height="16" rx="4" fill="#0f3460"/>
+  <rect x="123" y="112" width="30" height="16" rx="4" fill="#0f3460"/>
+  <!-- Spacebar -->
+  <rect x="50" y="134" width="100" height="16" rx="4" fill="#0f3460"/>
+  <!-- Cursor blinking line -->
+  <rect x="90" y="44" width="3" height="22" rx="2" fill="#4f98a3" opacity="0.9"/>
+  <!-- Text lines -->
+  <rect x="30" y="48" width="55" height="4" rx="2" fill="#4f98a3" opacity="0.6"/>
+  <rect x="30" y="56" width="40" height="4" rx="2" fill="#4f98a3" opacity="0.3"/>
+  <!-- Glow effect -->
+  <rect x="138" y="88" width="22" height="20" rx="5" fill="#4f98a3" opacity="0.15"/>
+  <rect x="55" y="110" width="22" height="20" rx="5" fill="#4f98a3" opacity="0.15"/>
+</svg>


### PR DESCRIPTION
## Что добавлено\n\nSVG иконки для двух игр, у которых не было своего изображения:\n\n- `frontend/images/typing.svg` — клавиатура с подсвеченными клавишами (teal-акцент)\n- `frontend/images/rat.svg` — крыса с кусочком сыра\n\n## Использование\n\n```json\n\"image\": \"/frontend/images/typing.svg\"\n\"image\": \"/frontend/images/rat.svg\"\n```\n\nSVG весят ~2-3KB, масштабируются без потерь на любой размер карточки.