### PR TITLE
fix(security): CodeQL alerts — command injection, cors suppression

### DIFF
--- a/backend/admin/adminController.mjs
+++ b/backend/admin/adminController.mjs
@@ -10,7 +10,7 @@ dotenv.config({ path: envPath });
 
 import bcrypt from 'bcryptjs';
 import paseto from 'paseto';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import { query } from '../database/config.mjs';
 import { mailQuery } from '../database/mailDatabase.config.mjs';
 import { v4 as uuidv4 } from 'uuid';
@@ -270,15 +270,23 @@ export const createStaffMailbox = async (req, res) => {
   }
 };
 
+// Генерация SHA512-CRYPT хеша для Dovecot.
+// Пароль передаётся через stdin, а не через аргументы CLI — не виден в ps aux и /proc/<pid>/cmdline.
 function generateDovecotHash(password) {
-  try {
-    const saltRaw = execFileSync('openssl', ['rand', '-base64', '12']).toString().trim().replace(/[^a-zA-Z0-9]/g, '').substring(0, 16);
-    const hash = execFileSync('openssl', ['passwd', '-6', '-salt', saltRaw, password]).toString().trim();
-    return `{SHA512-CRYPT}${hash}`;
-  } catch (error) {
-    console.error('[admin] ошибка генерации хеша, используем PLAIN:', error);
-    return `{PLAIN}${password}`;
+  const saltRaw = execFileSync('openssl', ['rand', '-base64', '12'])
+    .toString().trim().replace(/[^a-zA-Z0-9]/g, '').substring(0, 16);
+
+  const result = spawnSync(
+    'openssl',
+    ['passwd', '-6', '-stdin', '-salt', saltRaw],
+    { input: password + '\n', encoding: 'utf8' }
+  );
+
+  if (result.status !== 0 || !result.stdout) {
+    throw new Error(`[admin] openssl passwd завершился с ошибкой: ${result.stderr || 'неизвестная ошибка'}`);
   }
+
+  return `{SHA512-CRYPT}${result.stdout.trim()}`;
 }
 
 export default { loginAdmin, logoutAdmin, getMe, createEmployee, listEmployees, updateEmployee, deleteEmployee, createStaffMailbox };

--- a/backend/routes/routes.mjs
+++ b/backend/routes/routes.mjs
@@ -27,7 +27,7 @@ export function connectRoutes(app, authLimiter) {                               
     app.use(yookassaRouter);                                                                                                     // Подключаем маршруты платёжной системы YooKassa
 
     app.use('/auth', authLimiter);                                                                                               // Применяем более строгий лимит к маршрутам аутентификации
-    app.use('/auth', authRoutes);                                                                                                // Подключаем маршруты аутентификации с префиксом /auth
+    app.use('/auth', authRoutes);                                                                                               // Подключаем маршруты аутентификации с префиксом /auth
     app.use('/profile', profilesRoutes);                                                                                         // Подключаем маршруты профилей с префиксом /profile
     app.use('/counter', counterRoutes);                                                                                          // Подключаем маршруты счетчиков с префиксом /counter
     app.use('/api', analyticsRouter);                                                                                            // Подключаем маршруты аналитики страницы промокодов
@@ -48,6 +48,8 @@ export function connectRoutes(app, authLimiter) {                               
     app.use('/api/agents', agentsRouter);                                                                                        // Подключаем маршруты агентов
     app.use('/api/agents', subscriptionsRouter);                                                                                 // Подключаем маршруты подписок на агентов
     app.use('/api/agents', logsRouter);                                                                                          // Подключаем маршруты логов агентов
+    // Gateway открыт для внешних клиентов, авторизация через Bearer-токен — cookies не используются, origin: '*' безопасен.
+    // codeql[js/cors-permissive-configuration]
     app.use('/gateway', cors({ origin: '*', methods: ['GET', 'POST', 'OPTIONS'], allowedHeaders: ['Authorization', 'Content-Type', 'X-Buyer-Token'] })); // Gateway открыт для внешних клиентов — авторизация через токен
     app.use('/gateway', gatewayRouter);                                                                                          // Подключаем гетвей прокси агентов
     app.use('/', newsRoutes);                                                                                                    // Подключаем маршруты новостей (GET /news, GET /news/topics, POST /news/refresh)


### PR DESCRIPTION
## Что исправлено

### Fix #1 — `adminController.mjs`: command-line-injection

Пароль в `generateDovecotHash` передавался как аргумент CLI в `openssl passwd` — был виден в `ps aux` и `/proc/<pid>/cmdline`.

**Было:**
```js
execFileSync('openssl', ['passwd', '-6', '-salt', saltRaw, password])
```

**Стало:**
```js
spawnSync('openssl', ['passwd', '-6', '-stdin', '-salt', saltRaw], { input: password + '\n', encoding: 'utf8' })
```

Также убран небезопасный fallback `{PLAIN}${password}` — при ошибке хеширования теперь бросается исключение вместо сохранения пароля в открытом виде.

---

### Fix #3 — `routes/routes.mjs`: cors-permissive-configuration

`origin: '*'` на `/gateway` — намеренный и безопасный: авторизация через Bearer-токен, cookies не используются. Добавлена CodeQL-супрессия и комментарий с пояснением.

---

### Не включено в PR
- **Fix #2** (`server.mjs`, CSRF middleware) — отложен, требует отдельного тестирования.