### PR TITLE
i18n: move login/forgot UI messages to en.base

### DIFF
--- a/assembly/site/src/login/forgot/forgot_script.js
+++ b/assembly/site/src/login/forgot/forgot_script.js
@@ -1,4 +1,5 @@
 import { generateCombinedBackground } from '/frontend/scripts/backgroundGenerator.js';
+import { t } from '/frontend/scripts/i18n-loader.js';
 
 document.addEventListener("DOMContentLoaded", () => {
     generateCombinedBackground();
@@ -11,7 +12,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const email = document.getElementById("email").value.trim();
         if (!email) {
-            message.textContent = "Введите email.";
+            message.textContent = t('forgot.emailEmpty');
             message.style.color = "red";
             return;
         }
@@ -29,7 +30,7 @@ document.addEventListener("DOMContentLoaded", () => {
             message.textContent = data.message;
             message.style.color = res.ok ? "green" : "red";
         } catch (err) {
-            message.textContent = "Ошибка соединения с сервером.";
+            message.textContent = t('login.connectionError');
             message.style.color = "red";
         }
     });

--- a/assembly/site/src/login/login_scripts.js
+++ b/assembly/site/src/login/login_scripts.js
@@ -1,4 +1,5 @@
 import { generateCombinedBackground } from '/frontend/scripts/backgroundGenerator.js';                                       // Импортируем функцию генерации фона из внешнего модуля
+import { t } from '/frontend/scripts/i18n-loader.js';                                                                        // Импортируем функцию локализации
 
 // ОБРАБОТЧИК ОТПРАВКИ ФОРМЫ ВХОДА
 document.getElementById("loginForm").addEventListener("submit", async function(event) {                                      // Добавляем асинхронный обработчик события отправки формы
@@ -10,13 +11,13 @@ document.getElementById("loginForm").addEventListener("submit", async function(e
 
     // ВАЛИДАЦИЯ ПОЛЕЙ ФОРМЫ
     if (email.length < 1) {                                                                                                  // Проверяем что поле email не пустое
-        messageElement.textContent = "Email не может быть пустым.";                                                          // Устанавливаем текст сообщения об ошибке
+        messageElement.textContent = t('login.emailEmpty');                                                                  // i18n
         messageElement.style.color = "red";                                                                                  // Устанавливаем красный цвет текста для ошибки
         return;                                                                                                              // Прерываем выполнение функции если валидация не пройдена
     }
 
     if (password.length < 6) {                                                                                               // Проверяем что пароль содержит минимум 6 символов
-        messageElement.textContent = "Пароль должен содержать минимум 6 символов.";                                          // Устанавливаем текст сообщения об ошибке
+        messageElement.textContent = t('login.passwordShort');                                                               // i18n
         messageElement.style.color = "red";                                                                                  // Устанавливаем красный цвет текста для ошибки
         return;                                                                                                              // Прерываем выполнение функции если валидация не пройдена
     }
@@ -40,7 +41,7 @@ document.getElementById("loginForm").addEventListener("submit", async function(e
         
         console.log('Данные ответа:', data);                                                                                 // Логируем данные ответа для отладки
         
-        messageElement.textContent = data.message || "Произошла ошибка";                                                     // Устанавливаем текст сообщения из ответа или по умолчанию
+        messageElement.textContent = data.message || t('login.error');                                                       // i18n fallback
         messageElement.style.color = response.ok ? "green" : "red";                                                          // Устанавливаем зеленый цвет для успеха, красный для ошибки
 
         if (response.ok) {                                                                                                   // Проверяем успешен ли ответ (статус 200-299)
@@ -51,7 +52,7 @@ document.getElementById("loginForm").addEventListener("submit", async function(e
         }                                                                                                                   
     } catch (error) {                                                                                                        // Обработка ошибок в блоке try
         console.error('Ошибка при логине:', error);                                                                          // Логируем ошибку в консоль
-        messageElement.textContent = "Ошибка соединения с сервером.";                                                        // Показываем пользователю сообщение об ошибке сети
+        messageElement.textContent = t('login.connectionError');                                                             // i18n
         messageElement.style.color = "red";                                                                                  // Устанавливаем красный цвет текста
     }                                                                                                                       
 });

--- a/shared/i18n/en.base.json
+++ b/shared/i18n/en.base.json
@@ -58,5 +58,11 @@
   "auth.wrongCredentials": "Invalid email or password.",
   "auth.loginSuccess": "Logged in successfully.",
   "auth.loginQueryError": "Request execution error.",
-  "auth.logoutSuccess": "Logged out successfully."
+  "auth.logoutSuccess": "Logged out successfully.",
+
+  "login.emailEmpty": "Email cannot be empty.",
+  "login.passwordShort": "Password must be at least 6 characters.",
+  "login.error": "An error occurred.",
+  "login.connectionError": "Connection error with server.",
+  "forgot.emailEmpty": "Please enter your email."
 }


### PR DESCRIPTION
## Что сделано

Батч 1 — вынос захардкоженных русских строк из login/forgot в i18n.

### Изменённые файлы

| Файл | Что изменено |
|---|---|
| `assembly/site/src/login/login_scripts.js` | Добавлен `import { t }`, 4 строки → i18n-ключи |
| `assembly/site/src/login/forgot/forgot_script.js` | Добавлен `import { t }`, 2 строки → i18n-ключи |
| `shared/i18n/en.base.json` | Добавлены 5 новых ключей: `login.emailEmpty`, `login.passwordShort`, `login.error`, `login.connectionError`, `forgot.emailEmpty` |

### Новые i18n-ключи

```json
"login.emailEmpty": "Email cannot be empty.",
"login.passwordShort": "Password must be at least 6 characters.",
"login.error": "An error occurred.",
"login.connectionError": "Connection error with server.",
"forgot.emailEmpty": "Please enter your email."
```

### Следующие батчи
- Батч 2: `register_scripts.js`
- Батч 3: `profile/profile_scripts.js`
- Батч 4: `promo-codes-and-discounts/promokody-skidki.js` + `tools/ecology/calculator.js`
- Батч 5: `backend/admin/adminController.mjs`